### PR TITLE
Remove link check script from Travis CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ python:
 install:
 - pip install Sphinx sphinx_rtd_theme doc8
 before_install:
-- chmod +x ./docs/scripts/sphinx_build_link_check.sh
 - chmod +x ./docs/scripts/doc8_style_check.sh
 script:
 - cd docs
-- "./scripts/sphinx_build_link_check.sh"
 - "./scripts/doc8_style_check.sh"
 notifications:
   slack:


### PR DESCRIPTION
This link check script routinely raises false-negatives and causes
builds to fail. We can remove this for now to save headaches.

Signed-off-by: Steven Esser <sesser@nexb.com>