### PR TITLE
Issue #80 Resolve

### DIFF
--- a/docs/source/aboutcode-toolkit/home.rst
+++ b/docs/source/aboutcode-toolkit/home.rst
@@ -32,7 +32,7 @@ identify redistributable source code used in your project to help you comply
 with open source licenses conditions.
 
 This version of the AboutCode Toolkit follows the ABOUT specification version 3.2.1 at:
-https://aboutcode-toolkit.readthedocs.io/en/latest/specificaltion.html
+https://aboutcode-toolkit.readthedocs.io/en/latest/specification.html
 
 
 REQUIREMENTS

--- a/docs/source/aboutcode-toolkit/home.rst
+++ b/docs/source/aboutcode-toolkit/home.rst
@@ -32,7 +32,7 @@ identify redistributable source code used in your project to help you comply
 with open source licenses conditions.
 
 This version of the AboutCode Toolkit follows the ABOUT specification version 3.0 at:
-https://github.com/nexB/aboutcode-toolkit/blob/develop/SPECIFICATION.rst
+https://aboutcode-toolkit.readthedocs.io/en/latest/specificaltion.html
 
 
 REQUIREMENTS

--- a/docs/source/aboutcode-toolkit/home.rst
+++ b/docs/source/aboutcode-toolkit/home.rst
@@ -31,7 +31,7 @@ In addition, this tool is able to generate attribution notices and
 identify redistributable source code used in your project to help you comply
 with open source licenses conditions.
 
-This version of the AboutCode Toolkit follows the ABOUT specification version 3.0 at:
+This version of the AboutCode Toolkit follows the ABOUT specification version 3.2.1 at:
 https://aboutcode-toolkit.readthedocs.io/en/latest/specificaltion.html
 
 


### PR DESCRIPTION
Fixes #80 

Changed https://github.com/nexB/aboutcode-toolkit/blob/develop/SPECIFICATION.rst to https://aboutcode-toolkit.readthedocs.io/en/latest/specificaltion.html in docs/source/aboutcode-toolkit/home.rst line35

Now it works fine the previous link was dead now this link works

Prabal Rawal