### PR TITLE
Publish PDF version of RTD documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+# Build PDF & ePub
+formats:
+  - epub
+  - pdf
+
 # Where the Sphinx conf.py file is located
 sphinx:
    configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@
 # Required
 version: 2
 
-# Build PDF & ePub
+# Enabling options to download pdf and epub versions
 formats:
   - epub
   - pdf


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #125

I have added pdf and epub options in the .readthedocs.yaml file and have tested the documentation in readthedocs. The pdf and epub versions of the documentation can now be downloaded.
As per the screenshot below, the option to download pdf version is shown in the red rectangle.
![pdf_screenshot](https://github.com/nexB/aboutcode/assets/12524022/01309def-6eb7-491f-911d-606718c064f7)

After clicking on the above link, the pdf document appears in a browser tab as shown below-
![pdf_file_screenshot](https://github.com/nexB/aboutcode/assets/12524022/3cad0a26-d045-413f-8021-b9e2567ce504)

This fixes issue #125 

Let me know if any other changes are required in this PR.

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://aboutcode.readthedocs.io/en/latest/doc_maintenance.html#continuous-integration) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
Signed-off-by: Arijit De <arijitde2050@gmail.com>