### PR TITLE
Publish PDF version of RTD documentation #125

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+# Build PDF & ePub
+formats:
+  - epub
+  - pdf
+
 # Where the Sphinx conf.py file is located
 sphinx:
    configuration: docs/source/conf.py

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,3 +97,9 @@ rst_prolog = """
 .. role:: img-title-para
 
 """
+
+# -- Options for LaTeX output -------------------------------------------------
+
+latex_elements = {
+    'classoptions': ',openany,oneside'
+}


### PR DESCRIPTION
Made changes in the .readthedocs.yaml to enable format for downloading pdf and epub versions of the documentation

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #125

I have added pdf and epub options in the .readthedocs.yaml file and have tested the documentation in readthedocs. The pdf and epub versions of the documentation can now be downloaded.
As per the screenshot below, the option to download pdf version is shown in the red rectangle.
![pdf_screenshot](https://github.com/nexB/aboutcode/assets/12524022/9ed0dda4-56d1-42fc-b06b-a770a4944df1)


After clicking on the above link, the pdf document appears in a browser tab as shown below-
![pdf_file_screenshot](https://github.com/nexB/aboutcode/assets/12524022/7ffa211d-ccb2-49f1-bb74-6569837427c0)


This fixes issue https://github.com/nexB/aboutcode/issues/125

Let me know if any other changes are required in this PR.
<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://aboutcode.readthedocs.io/en/latest/doc_maintenance.html#continuous-integration) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
Signed-off-by: Arijit De [arijitde2050@gmail.com](mailto:arijitde2050@gmail.com)