### PR TITLE
Update AboutCode README and RTD Home Page for Consistency & Modernization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,148 +2,143 @@
 
 ### What is AboutCode?
 
-AboutCode is a family of FOSS projects to uncover data ... about software:
+AboutCode is a family of free and open-source tools that help organizations
+understand *what* software they are using, *where* it comes from, *how* it is
+licensed, and *whether it is safe to use*. Our tools analyze source code,
+packages, containers, and build artifacts to answer questions such as:
 
--   where does the code come from? which software package?
--   what is its license? copyright?
--   is the code vulnerable, maintained, well coded?
--   what are its dependencies, are there vulnerabilities/licensing issues?
+- Where does this code come from? Which package and version?
+- What is its license? What are the copyright details?
+- Are there vulnerabilities in this component?
+- What dependencies does it use? Are they maintained or risky?
 
-All these are questions that are important to answer: there are millions of free
-and open source software components available on the web for reuse.
+Millions of open-source packages are available on the internet.  
+AboutCode provides tools that make it easy and reliable to consume open source
+safely by generating high-quality, reusable open data.
 
-Knowing where a software package comes from, what its license is and whether it
-is vulnerable should be a problem of the past such that everyone can safely
-consume more free and open source software. We support not only open source
-software, but also open data, generated and curated by our applications.
+> **Note**  
+> This repository provides overview information about AboutCode.  
+> Project-specific code and documentation are available in each project’s own
+> repository (see **Projects** below).
 
-> [!NOTE]
-> This is a repository with information on aboutcode open source
-> activities and not the actual code repository. See the
-> [projects section](https://github.com/aboutcode-org/aboutcode#projects) below
-> for links to all the code repositories of our projects with a brief overview
-> and our [wiki](https://github.com/aboutcode-org/aboutcode/wiki) if you are
-> looking to participate.
+---
 
 ### Documentation Build
 
 ![Doc Build](https://github.com/aboutcode-org/aboutcode/actions/workflows/docs-ci.yml/badge.svg)
 
-> [!NOTE]
-> To manually build the documentation, run the `$ make docs` command from 
-> the root of this repo.
+To build the documentation manually:
+
+```
+make docs
+```
+
+---
 
 ### Important Links
 
-Our homepage is at http://aboutcode.org
+- Website: https://aboutcode.org  
+- Documentation: https://aboutcode.readthedocs.io/en/latest/  
+- Community Chat:  
+  - Gitter/Matrix: https://matrix.to/#/#aboutcode-org_discuss:gitter.im  
+- GSoC Information:  
+  https://github.com/aboutcode-org/aboutcode/wiki  
+- Weekly Meetings:  
+  https://github.com/aboutcode-org/aboutcode/wiki/MeetingMinutes
 
-Our documentation (in progress) is at
-https://aboutcode.readthedocs.io/en/latest/
+---
 
-Join the chat online at
-[app.gitter.im : aboutcode-org#discuss](https://app.gitter.im/#/room/#aboutcode-org_discuss:gitter.im)
-or if you're using the element app set the homeserver to `gitter.im` and then
-join the
-[aboutcode-org#discuss](https://matrix.to/#/#aboutcode-org_discuss:gitter.im)
-chatroom. Introduce yourself and start the discussion!
+# Projects
 
-Look at our [wiki](https://github.com/aboutcode-org/aboutcode/wiki) for
-information about our participation in the GSoC program.
+AboutCode consists of multiple open-source projects.  
+Each project has its own repository and documentation.
 
-We have a weekly meeting, see more details
-[here](https://github.com/aboutcode-org/aboutcode/wiki/MeetingMinutes).
+## 🔹 **Primary Projects**
 
-### Projects
+### **ScanCode Toolkit**  
+https://github.com/aboutcode-org/scancode-toolkit  
+Detects licenses, copyrights, package metadata, dependencies, and file
+origins. Uses a flexible plug-in architecture.  
+Maintainer: @pombredanne
 
-Each AboutCode project has its own repository:
+### **Scancode.io**  
+https://github.com/aboutcode-org/scancode.io  
+Web application and API for managing ScanCode workflows, pipelines, and
+container/package analysis.  
+Maintainer: @tdruez
 
--   **[ScanCode Toolkit](https://github.com/aboutcode-org/scancode-toolkit)**: a
-    set of code scanning tools to detect the origin and license of code and
-    dependencies. ScanCode now uses a plug-in architecture to run a series of
-    scan-related tools in one process flow. This is the most popular project and
-    is used by 100's of software teams . The lead maintainer is @pombredanne
+### **VulnerableCode**  
+https://github.com/aboutcode-org/vulnerablecode  
+Aggregates and normalizes vulnerability data for software packages. Provides an
+API and web UI. Includes Vulntotal.  
+Maintainers: @tg1999, @pombredanne
 
--   **[Scancode.io](https://github.com/aboutcode-org/scancode.io)**: is a
-    web-based and API to run and review scans in rich scripted pipelines, on
-    different kinds of containers, docker images, package archives, manifests
-    etc, to get information on licenses, copyrights, source, vulneribilities.
-    The lead maintainer is @tdruez
+### **purlDB**  
+https://github.com/aboutcode-org/purldb  
+Database and collection pipelines for Package URLs (purl). Contains package
+metadata and relationships.  
+Maintainer: @jyang
 
--   **[VulnerableCode](https://github.com/aboutcode-org/vulnerablecode)**: is a
-    web-based API and database to collect and track all the known software
-    package vulnerabilities, with affected and fixed packages, references and a
-    standalone tool Vulntotal to compare this vulneribility information across
-    similar tools. This is maintained by @tg1999 and @pombredanne
+### **univers**  
+https://github.com/aboutcode-org/univers  
+Library to parse, compare, and match package versions and version ranges.
 
--   **[univers](https://github.com/aboutcode-org/univers)** is a package to
-    parse and compare all the package versions and all the ranges.
+### **ScanCode Workbench**  
+https://github.com/aboutcode-org/scancode-workbench  
+Desktop UI for reviewing and visualizing ScanCode Toolkit scan results.
 
--   **[purlDB](https://github.com/aboutcode-org/purldb)** consists of tools to
-    create and expose a database of purls (Package URLs) and also has package
-    data for all of these packages created from scans. This is maintained by
-    @jyang
+### **AboutCode Toolkit**  
+https://github.com/aboutcode-org/aboutcode-toolkit  
+Tools to document code provenance and generate attribution notices.  
+Maintainer: @chinyeungli
 
--   **[FetchCode](https://github.com/aboutcode-org/fetchcode)** is a library to
-    reliably fetch any code via HTTP, FTP and version control systems such as
-    git.
+---
 
--   **[Scancode Workbench](https://github.com/aboutcode-org/scancode-workbench)**:
-    a desktop application based on typescript and react to visualize and review
-    scan results from scancode scans.
+## 🔹 **Supporting Tools**
 
--   **[AboutCode Toolkit](https://github.com/aboutcode-org/aboutcode-toolkit)**:
-    a set of command line tools to document the provenance of your code and
-    generate attribution notices. AboutCode Toolkit uses small yaml files to
-    document code provenance inside a codebase. The lead maintainer is
-    @chinyeungli
+### **FetchCode**  
+https://github.com/aboutcode-org/fetchcode  
+Reliable code fetcher for HTTP, FTP, Git, and other version control systems.
 
--   **[container-inspector](https://github.com/aboutcode-org/container-inspector)**:
-    a tool to analyze the structure and provenance of software components in
-    Docker images using static analysis. Maintained by @pombredanne
+### **container-inspector**  
+https://github.com/aboutcode-org/container-inspector  
+Analyzes Docker and OCI images for component provenance.  
+Maintainer: @pombredanne
 
--   **[python-inspector](https://github.com/aboutcode-org/python-inspector)**
-    and **[nuget inspector](https://github.com/aboutcode-org/nuget-inspector/)**
-    inspects manifests and code to resolve dependencies (vulnerable and
-    non-vulnerable) for python and nuget packages respectively.
+### **python-inspector**  
+https://github.com/aboutcode-org/python-inspector  
+Dependency resolver for Python packages.
 
--   **[license-expression](https://github.com/aboutcode-org/license-expression/)**:
-    a library to parse, analyze, compare and normalize SPDX and SPDX-like
-    license expressions using a boolean logic expression engine. See
-    https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60 to
-    understand what an expression is. See
-    https://github.com/aboutcode-org/license-expression for the code. The
-    underlying boolean engine is live at https://github.com/bastikr/boolean.py .
-    Both are co-maintained by @pombredanne
+### **nuget-inspector**  
+https://github.com/aboutcode-org/nuget-inspector  
+Dependency resolver for NuGet packages.
 
--   **ABCD aka AboutCode Data**: a simple set of conventions to define data
-    structures that all the AboutCode tools can understand and use to exchange
-    data. The details are at
-    [AboutCode Data](https://aboutcode.readthedocs.io/en/latest/aboutcode-data/abcd.html).
-    ABOUT files and ScanCode Toolkit data are examples of this approach. Other
-    projects such as https://libraries.io and and
-    [OSS Review Toolkit](https://github.com/heremaps/oss-review-toolkit) are
-    also using these conventions.
+### **license-expression**  
+https://github.com/aboutcode-org/license-expression  
+Parses, normalizes, and evaluates SPDX and SPDX-like license expressions.
 
--   **[TraceCode Toolkit](https://github.com/aboutcode-org/tracecode-toolkit)**:
-    a set of tools to trace files from your deployment or distribution packages
-    back to their origin in a development codebase or repository. The primary
-    tool uses strace https://github.com/strace/strace/ to trace system calls on
-    Linux and construct a build graph from syscalls to show which files are used
-    to build a binary. We are contributors to strace. Maintained by @pombredanne
+### **ABCD — AboutCode Data**  
+Shared data model used across many AboutCode tools.  
+Documentation:  
+https://aboutcode.readthedocs.io/en/latest/aboutcode-data/abcd.html
 
-We also co-started and worked closely with other FOSS orgs and projects:
+---
 
--   [Package URL](https://github.com/package-url): a widely used standard to
-    reference software packages of all types with simple, readable and concise
-    URLs.
+## 🔹 **Standards & Ecosystem Projects**
 
--   [SPDX](http://SPDX.org): aka. Software Package Data Exchange, a spec to
-    document the origin and licensing of packages.
+- **Package URL (purl)**  
+  https://github.com/package-url  
+  Open standard for identifying software packages.
 
--   [CycloneDX](https://cyclonedx.org) aka. OWASP CycloneDX is a full-stack Bill
-    of Materials (BOM) standard that provides advanced supply chain capabilities
-    for cyber risk reduction
+- **SPDX**  
+  https://spdx.org  
+  Industry standard for license and package metadata.
 
--   [ClearlyDefined](https://ClearlyDefined.io): a project to review and help
-    FOSS projects improve their licensing and documentation clarity. This
-    project is incubating with https://opensource.org
+- **CycloneDX**  
+  https://cyclonedx.org  
+  SBOM standard from OWASP for supply-chain security.
+
+- **ClearlyDefined**  
+  https://clearlydefined.io  
+  Community project to improve FOSS licensing documentation.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,48 +1,62 @@
-#########
 AboutCode
-#########
+=========
 
-Welcome to the AboutCode documentation homepage. `AboutCode.org
-<https://www.aboutcode.org/>`_ is a community of open source developers who
-are trying to make open source easier to use by providing open source tools
-to discover, identify and track open source components (aka Software
-Composition Analysis – SCA). AboutCode is the collective name for these
-open source tools.
+AboutCode is a family of free and open-source tools that help organizations
+understand what software they use, where it comes from, how it is licensed, and
+whether it is safe. These tools analyze source code, packages, containers, and
+build artifacts to answer essential software supply-chain questions.
 
-This home page provides a directory of our major projects and their
-documentation on ReadTheDocs plus information about how to contribute to
-AboutCode documentation.
+This documentation provides an overview of the AboutCode ecosystem, with links
+to individual projects and their documentation.
 
-All community contributions are welcome.
+Primary Projects
+----------------
 
+* **ScanCode Toolkit** – Detect licenses, copyrights, packages, metadata,
+  dependencies, and file origins.  
+  https://github.com/aboutcode-org/scancode-toolkit
 
-----
+* **Scancode.io** – Web UI and API for ScanCode pipelines and container/package
+  analysis.  
+  https://github.com/aboutcode-org/scancode.io
 
-********
-Overview
-********
+* **VulnerableCode** – Unified vulnerability database and APIs.  
+  https://github.com/aboutcode-org/vulnerablecode
 
-.. toctree::
-   :maxdepth: 3
+* **purlDB** – Package URL database and package metadata pipelines.  
+  https://github.com/aboutcode-org/purldb
 
-   aboutcode-project-overview
+* **univers** – Version and version-range parsing and comparison utilities.  
+  https://github.com/aboutcode-org/univers
 
-************
-Contributing
-************
+Supporting Tools
+----------------
 
-.. toctree::
-   :maxdepth: 3
+* **FetchCode** – Reliable code fetching library  
+  https://github.com/aboutcode-org/fetchcode
 
-   contributing
+* **container-inspector** – OCI/Docker image inspection  
+  https://github.com/aboutcode-org/container-inspector
 
-******
-Others
-******
+* **python-inspector**, **nuget-inspector** – Dependency resolvers  
+  https://github.com/aboutcode-org/python-inspector  
+  https://github.com/aboutcode-org/nuget-inspector
 
-.. toctree::
-   :maxdepth: 2
+* **license-expression** – SPDX expression parsing and normalization  
+  https://github.com/aboutcode-org/license-expression
 
-   aboutcode-data/abcd
-   archive
-   license
+Standards & Collaborations
+--------------------------
+
+* **Package URL (purl)** – Open standard for package identifiers  
+  https://github.com/package-url
+
+* **SPDX** – Software Package Data Exchange  
+  https://spdx.org
+
+* **CycloneDX** – SBOM specification from OWASP  
+  https://cyclonedx.org
+
+* **ClearlyDefined** – Community project for improving FOSS licensing  
+  https://clearlydefined.io
+


### PR DESCRIPTION
This PR updates and synchronizes the AboutCode project overview across the GitHub README and the ReadTheDocs home page.
Goals of the PR
Bring README.md content up to date.

Ensure the RTD home page at
https://aboutcode.readthedocs.io/en/latest/index.html

reflects the same information with consistent structure and wording.

Modernize the description of AboutCode and explain the ecosystem clearly.

Fix typos, outdated descriptions, inconsistent formatting.

Provide a maintainable process for keeping README + RTD synced.