### PR TITLE
Improve issue referencing standards in contributing guidelines (#106)

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -3,7 +3,7 @@ Contributing to AboutCode
 #########################
 
 We welcome you and your interest in contributing to open source software!
-AboutCode is always looking for enthusiatic contributors and we are happy
+AboutCode is always looking for enthusiastic contributors and we are happy
 to help with any questions or comments. Here a few resources to get
 started:
 

--- a/docs/source/contributing/writing_good_commit_messages.rst
+++ b/docs/source/contributing/writing_good_commit_messages.rst
@@ -19,7 +19,13 @@ The main style points are these:
 
 Subject:
 
-- Add a issue number at the end of the line when available as in "#234"
+- Add an issue reference at the end of the line when available. For commit 
+  messages within the same repository, you can use the shorthand format like 
+  "Fixes #234". However, for code comments or cross-repository references, 
+  always use full GitHub URLs (e.g., 
+  "https://github.com/aboutcode-org/aboutcode/issues/234") to prevent broken 
+  references if the code is moved to another repository. See 
+  https://github.com/aboutcode-org/aboutcode/issues/106 for more context.
 - Limit the subject line to 50 characters
 - Capitalize the subject line
 - Do not end the subject line with a period
@@ -38,15 +44,16 @@ Body:
 
 Other comments:
 
-We like to suffix the subject line with an issue number. If this was a
-trivial change it may not have one though. If it had one a you would use
-``#156`` as a suffix to the first line.
+We like to suffix the subject line with an issue reference. If this was a
+trivial change it may not have one though. For commits within this repository,
+you can use the shorthand ``#156`` as a suffix to the first line. For code 
+comments that might be moved to other repositories, use full URLs.
 
 We like to tell why the commit is there and use an imperative style, like
 if you were giving an order to the codebase with your commit:
 
 e.g rather than : ``Minor fix for unnecessary operations.`` may be ``Remove
-unnecessary operations #123`` or::
+unnecessary operations https://github.com/aboutcode-org/aboutcode/issues/123`` or::
 
     Remove unnecessary operations #123
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/aboutcode-org/aboutcode/issues/106

Updates contributing guidelines to recommend full GitHub URLs for issue references instead of shorthand numbers, preventing broken references when code is moved between repositories.

## Changes Made
- Fixed typo in `contributing.rst`: "enthusiatic" → "enthusiastic"
- Updated `writing_good_commit_messages.rst` to recommend full GitHub URLs (e.g., `https://github.com/aboutcode-org/aboutcode/issues/234`) for code comments and cross-repository references
- Clarified that shorthand format (`#234`) is acceptable for commit messages within the same repository
- Added reference to the original issue for context

## Rationale
When code or documentation is moved to a different repository, shorthand issue references (`#123`) will point to a completely different issue in the new repo, breaking traceability. Full URLs remain valid regardless of where the code lives.

## Testing
- Reviewed git diff to verify changes
- Confirmed RST syntax is correct
- CI will run full Sphinx documentation build to ensure no errors

## Before / After
**Before**: Contributors were instructed to use `#234` for all issue references
**After**: Contributors are now guided to use full URLs for code comments and cross-repo references, with shorthand accepted for commit messages within the same repository