### PR TITLE
feat: Add Release Automation Kit (Issue #122)

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,37 @@
+# Release Automation Kit
+
+This directory contains tools to automate the posting of release news to the `aboutcode.org` website.
+
+## Components
+
+1.  **`generate_release_post.py`**: A Python script that generates a formatted ReStructuredText (RST) file for the news section.
+2.  **`release-workflow-template.yml`**: A GitHub Actions workflow template that can be used in AboutCode projects (like ScanCode, VulnerableCode) to automatically trigger this process on release.
+
+## Usage
+
+### Local Usage
+
+You can use the script locally to generate a news file:
+
+```bash
+python3 generate_release_post.py \
+  --project "ScanCode Toolkit" \
+  --version "32.0.1" \
+  --url "https://github.com/aboutcode-org/scancode-toolkit/releases/tag/v32.0.1" \
+  --output-dir "output"
+```
+
+This will create a file like `2023-10-27-scancode-toolkit-v32.0.1-released.rst` in the output directory.
+
+### GitHub Actions Integration
+
+To automate this for a project:
+
+1.  Copy `release-workflow-template.yml` to the project's `.github/workflows/` directory.
+2.  Update the `PROJECT_NAME` environment variable in the workflow file.
+3.  Configure the `create-pull-request` step to point to the correct `aboutcode.org` source repository (if different from the current one) and ensure a `BOT_TOKEN` with sufficient permissions is available in the repository secrets.
+
+## Requirements
+
+- Python 3.6+
+- No external dependencies for the script (uses standard library).

--- a/automation/generate_release_post.py
+++ b/automation/generate_release_post.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Release Post Generator for AboutCode.org
+
+This script generates a news post file for a new project release.
+It is designed to be used in GitHub Actions workflows.
+
+Usage:
+    python3 generate_release_post.py --project "Project Name" --version "1.0.0" --url "https://..." --date "2023-10-27" --output-dir "news"
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+TEMPLATE = """
+{title}
+{title_underline}
+
+AboutCode is happy to announce the release of **{project} v{version}**!
+
+Check out the full release notes and download it here:
+{url}
+
+Visit the project homepage:
+{homepage}
+
+-- The AboutCode Team
+"""
+
+PROJECT_HOMEPAGES = {
+    "ScanCode Toolkit": "https://github.com/aboutcode-org/scancode-toolkit",
+    "ScanCode.io": "https://github.com/aboutcode-org/scancode.io",
+    "VulnerableCode": "https://github.com/aboutcode-org/vulnerablecode",
+    "DejaCode": "https://github.com/aboutcode-org/dejacode",
+    "PURLDB": "https://github.com/aboutcode-org/purldb",
+}
+
+def generate_post(project, version, url, date_str, output_dir):
+    """Generates the release post file."""
+    
+    # Format the title
+    title = f"{project} v{version} released"
+    title_underline = "=" * len(title)
+    
+    # Get homepage or default to github organization
+    homepage = PROJECT_HOMEPAGES.get(project, "https://github.com/aboutcode-org")
+    
+    content = TEMPLATE.format(
+        title=title,
+        title_underline=title_underline,
+        project=project,
+        version=version,
+        url=url,
+        homepage=homepage
+    ).strip()
+    
+    # Create filename: YYYY-MM-DD-project-vVERSION-released.rst (Sphinx uses RST usually)
+    # Using RST as AboutCode docs are RST-heavy
+    safe_project_name = project.lower().replace(" ", "-").replace(".", "")
+    filename = f"{date_str}-{safe_project_name}-v{version}-released.rst"
+    
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        filepath = os.path.join(output_dir, filename)
+    else:
+        filepath = filename
+
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(content)
+        f.write("\n")
+        
+    print(f"Successfully generated release post: {filepath}")
+    return filepath
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate AboutCode release post")
+    parser.add_argument("--project", required=True, help="Project name (e.g., ScanCode.io)")
+    parser.add_argument("--version", required=True, help="Release version (e.g., 32.0.1)")
+    parser.add_argument("--url", required=True, help="Release URL")
+    parser.add_argument("--date", help="Date in YYYY-MM-DD format (default: today)")
+    parser.add_argument("--output-dir", default=".", help="Directory to save the file")
+    
+    args = parser.parse_args()
+    
+    date_str = args.date if args.date else datetime.now().strftime("%Y-%m-%d")
+    
+    try:
+        generate_post(args.project, args.version, args.url, date_str, args.output_dir)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/automation/release-workflow-template.yml
+++ b/automation/release-workflow-template.yml
@@ -1,0 +1,53 @@
+name: Publish Release News
+on:
+  release:
+    types: [published]
+
+jobs:
+  create-news-post:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Get Release Info
+        id: release_info
+        run: |
+          echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          echo "URL=${{ github.event.release.html_url }}" >> $GITHUB_ENV
+          echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+          # Extract project name from repo name or set manually
+          echo "PROJECT_NAME=ScanCode Toolkit" >> $GITHUB_ENV # TODO: Customize this per project
+
+      - name: Download Generator Script
+        run: |
+          # Downloads the generator script from the main AboutCode repo
+          curl -O https://raw.githubusercontent.com/aboutcode-org/aboutcode/main/automation/generate_release_post.py
+
+      - name: Generate Post
+        run: |
+          python3 generate_release_post.py \
+            --project "${{ env.PROJECT_NAME }}" \
+            --version "${{ env.VERSION }}" \
+            --url "${{ env.URL }}" \
+            --date "${{ env.DATE }}" \
+            --output-dir "news"
+
+      - name: Create Pull Request to Website Repo
+        # Note: This step assumes you are pushing to the website repo.
+        # AboutCode maintainers need to configure the target repository and token.
+        # This uses peter-evans/create-pull-request as an example.
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }} # Ensure this secret is set
+          path: news
+          commit-message: "docs: add release news for ${{ env.PROJECT_NAME }} ${{ env.VERSION }}"
+          title: "News: ${{ env.PROJECT_NAME }} ${{ env.VERSION }} Released"
+          body: "Automated release post for ${{ env.PROJECT_NAME }} ${{ env.VERSION }}"
+          branch: "news/${{ env.PROJECT_NAME }}-${{ env.VERSION }}"
+          base: main


### PR DESCRIPTION
Fixes #122

This PR introduces a **Release Automation Kit** to solve the manual overhead of posting release news to aboutcode.org.

### Changes
- **[automation/generate_release_post.py](cci:7://file:///c:/Users/anish/OneDrive/Desktop/aboutcode/aboutcode/automation/generate_release_post.py:0:0-0:0)**: A script that accepts release metadata (version, url, project) and outputs a correctly formatted News post (RST) compatible with the AboutCode website.
- **[automation/release-workflow-template.yml](cci:7://file:///c:/Users/anish/OneDrive/Desktop/aboutcode/aboutcode/automation/release-workflow-template.yml:0:0-0:0)**: A reusable GitHub Action workflow template. Maintainers can copy this to projects (like `scancode-toolkit`) to automatically trigger post generation and PR creation on new releases.
- **[automation/README.md](cci:7://file:///c:/Users/anish/OneDrive/Desktop/aboutcode/aboutcode/automation/README.md:0:0-0:0)**: Instructions on how to deploy this kit.

### Why this approach?
The `aboutcode.org` website source is not hosted in this repository. Therefore, we cannot directly automate the *write* operation here. Instead, this PR provides the **tooling infrastructure** that can be installed in the individual tool repositories to remotely push news updates to the website repo.