### PR TITLE
Add Security Policy (Issue #187)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+AboutCode.org and the nexB Inc. team take the security of our software products and services seriously.
+
+## Supported Versions
+
+We generally support the latest major version of our software. Please check the specific repository's `README.md` or release notes for detailed version support information.
+
+## Reporting a Vulnerability
+
+If you find a security vulnerability in any of our projects, please report it to us as soon as possible.
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via email to **security@aboutcode.org**.
+
+Please include as much information as possible in your report, including:
+*   The project and version affected.
+*   A description of the vulnerability.
+*   Steps to reproduce the issue (proof-of-concept code is helpful).
+*   The potential impact of the vulnerability.
+
+### Response Timeline
+
+We will acknowledge receipt of your report within 48 hours. We strive to fix valid critical vulnerabilities as quickly as possible and will keep you updated on our progress.
+
+## Best Practices
+
+We encourage security researchers to follow responsible disclosure practices:
+*   Give us reasonable time to fix the issue before making it public.
+*   Do not exploit the vulnerability to access or manipulate user data.
+*   Respect the privacy of our users.
+
+Thank you for helping keep the open source community secure!


### PR DESCRIPTION
Fixes #187. Adds \SECURITY.md\ to the repository root with vulnerability disclosure instructions.