### PR TITLE
Fix banner text visibility

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -24,3 +24,17 @@ div.rst-content {
         margin-left: 0px;
     }
 }
+
+
+
+/* Add proper spacing below the top navigation bar */
+.wy-nav-content {
+    padding-top: 80px; 
+}
+
+/* Improve visibility and spacing of large banner text */
+.section h1 {
+    margin-top: 20px;
+    margin-bottom: 20px;
+    line-height: 1.3;
+}


### PR DESCRIPTION
fixes #235 

 Summary
Improved the visibility of the banner text by adding appropriate spacing between the fixed navigation bar and the main content area.

Changes
- Added top padding to the main content container using theme overrides
- Improved spacing and readability of large banner headings

Reason
The banner text was appearing too close to or partially hidden by the navigation bar due to missing top spacing. This change ensures better readability and a cleaner UI without affecting existing layout behavior.

Notes
This fix is implemented using `theme_overrides.css` to safely override ReadTheDocs theme styles.
