### PR TITLE
docs: define core user roles and personas for community research

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,16 @@ Contributing
 
    contributing
 
+**********
+Community
+**********
+
+.. toctree::
+   :maxdepth: 2
+
+   user-roles-framework
+   slack-polling-guide
+
 ******
 Others
 ******

--- a/docs/source/slack-polling-guide.rst
+++ b/docs/source/slack-polling-guide.rst
@@ -1,0 +1,199 @@
+.. _slack-polling-guide:
+
+==========================
+Slack Polling Guide for User Roles
+==========================
+
+This guide explains how to conduct polls in Slack to gather user role information for the
+AboutCode community.
+
+Why Poll in Slack?
+------------------
+
+Slack polls are an effective way to:
+
+- Engage active community members
+- Gather information from users who are already participating
+- Get quick feedback without requiring formal surveys
+- Build community awareness of user diversity
+
+Preparing Your Poll
+-------------------
+
+Before creating a poll, consider:
+
+1. **Timing**: Post during active hours when most community members are online
+2. **Frequency**: Don't poll too frequently to avoid survey fatigue
+3. **Clarity**: Make questions clear and easy to answer
+4. **Anonymity**: Decide if responses should be anonymous or attributed
+
+Poll Options in Slack
+---------------------
+
+Slack offers several ways to conduct polls:
+
+**1. Native Slack Polls (Recommended)**
+    - Use Slack's built-in poll feature (if available in your workspace)
+    - Type `/poll` followed by your question and options
+    - Example: ``/poll "What's your primary role?" "Compliance Manager" "Security Engineer" "Developer" "Other"``
+
+**2. Emoji Reactions**
+    - Post a message with multiple options
+    - Ask users to react with specific emojis for each option
+    - Easy to set up and participate
+
+**3. Thread-based Responses**
+    - Post a question and ask users to reply in threads
+    - Allows for more detailed responses
+    - Good for open-ended questions
+
+**4. Third-party Poll Apps**
+    - Use Slack apps like Simple Poll, Polly, or SurveyMonkey
+    - More features but requires app installation
+
+Sample Poll Messages
+--------------------
+
+**Quick Role Identification Poll**
+
+.. code-block:: text
+
+    👋 Hey #general! We're working on understanding our community better to improve 
+    documentation and resources.
+    
+    Quick poll: What best describes your primary role with AboutCode tools?
+    
+    React with:
+    📋 = Compliance/Legal
+    🔒 = Security/Vulnerability Management  
+    💻 = Developer/Engineer
+    ⚙️ = DevOps/Operations
+    🎓 = Student/Researcher
+    👔 = Management/Product
+    🤝 = Contributor/Maintainer
+    ❓ = Other (reply in thread)
+
+**Detailed Role Information Request**
+
+.. code-block:: text
+
+    📊 Community Role Survey
+    
+    We're building a user roles framework to better serve our community. If you have 
+    a moment, please share:
+    
+    1. Your job title (or "Student" if applicable)
+    2. Are you primarily technical, not-so-technical, or non-technical?
+    3. Are you in a management role or individual contributor?
+    4. Your main interest: License Compliance, Cybersecurity, or both?
+    5. Your experience level: Beginner, Intermediate, Advanced, or Expert?
+    
+    Reply in this thread or DM me if you prefer. Thanks! 🙏
+
+**Multi-Question Poll Using Threads**
+
+.. code-block:: text
+
+    🎯 AboutCode User Roles - Help Us Understand You!
+    
+    Please reply to this message with your answers (copy/paste format below):
+    
+    Role Name: [e.g., "Open Source Compliance Manager"]
+    Job Title: [your job title]
+    Student/Professional: [one]
+    Technical Level: [Technical / Not-so-technical / Non-technical]
+    Management/Individual Contributor: [one]
+    Interested in License Compliance? [Yes/No]
+    Interested in Cybersecurity? [Yes/No]
+    Experience Level: [Beginner / Intermediate / Advanced / Expert]
+    Other Objectives: [any additional goals]
+    
+    Thanks for helping us improve! 🚀
+
+Best Practices
+--------------
+
+**Do:**
+- Keep polls short and focused
+- Make participation easy (emoji reactions are quickest)
+- Follow up with results and next steps
+- Thank participants
+- Use clear, simple language
+- Post at times when your community is active
+
+**Don't:**
+- Ask too many questions at once
+- Make polls mandatory
+- Use jargon or technical terms unnecessarily
+- Ignore responses or fail to follow up
+- Poll too frequently
+
+Following Up
+-----------
+
+After collecting responses:
+
+1. **Thank Participants**: Acknowledge those who participated
+2. **Share Results**: Summarize findings (anonymized if appropriate)
+3. **Explain Next Steps**: Tell the community how you'll use the information
+4. **Update Documentation**: Incorporate findings into the user roles framework
+5. **Iterate**: Use feedback to refine future polls
+
+Example Follow-up Message
+-------------------------
+
+.. code-block:: text
+
+    📊 Thanks to everyone who participated in our user roles poll! 
+    
+    We received responses from:
+    - 15 Compliance/Legal professionals
+    - 12 Security Engineers
+    - 20 Developers
+    - 8 DevOps Engineers
+    - 5 Students/Researchers
+    - 3 Managers
+    - 10 Contributors
+    
+    This helps us understand our community better. We'll be using this information 
+    to:
+    - Create role-specific documentation paths
+    - Tailor our getting-started guides
+    - Prioritize features that matter most to you
+    
+    Stay tuned for updates! 🎉
+
+Alternative: Using Google Forms or Similar
+------------------------------------------
+
+If you need more detailed responses, consider:
+
+1. **Google Forms**: Create a form and share the link in Slack
+2. **Typeform**: More interactive but requires account
+3. **SurveyMonkey**: Professional surveys with analysis tools
+
+Then share the form link in #general with a brief explanation.
+
+Example:
+
+.. code-block:: text
+
+    📋 We're conducting a user roles survey to better understand our community!
+    
+    Please take 2-3 minutes to fill out this form:
+    [link to form]
+    
+    Your responses help us improve documentation and prioritize features. 
+    All responses are anonymous unless you choose to share your contact info.
+
+Tips for Success
+----------------
+
+1. **Start Small**: Begin with a simple emoji reaction poll
+2. **Be Patient**: Not everyone will respond immediately
+3. **Remind Gently**: A follow-up reminder after 24-48 hours is okay
+4. **Make it Fun**: Use emojis and friendly language
+5. **Show Value**: Explain why their input matters
+
+Remember: The goal is to understand your community, not to collect data for its own sake.
+Use the information to improve the AboutCode experience for everyone!

--- a/docs/source/user-roles-framework.rst
+++ b/docs/source/user-roles-framework.rst
@@ -1,0 +1,183 @@
+.. _user-roles-framework:
+
+===========================
+AboutCode User Roles Framework
+===========================
+
+Overview
+--------
+
+This document defines a framework for identifying and categorizing the various types of users
+who are interested in AboutCode tools and projects. Understanding user roles helps us:
+
+- Address information needs more efficiently
+- Tailor documentation and resources to specific audiences
+- Improve user experience by providing role-appropriate guidance
+- Better understand our community composition
+
+Role Attributes
+---------------
+
+Each user role can be characterized by the following attributes:
+
+**Role Name**
+    A descriptive name for the role (e.g., "Open Source Compliance Manager", "Security Engineer")
+
+**Job Title**
+    Common job titles associated with this role (e.g., "Software Engineer", "Legal Counsel", "DevOps Manager")
+
+**Professional Status**
+    - Student
+    - Professional
+
+**Technical Level**
+    - Technical (hands-on with code/tools)
+    - Not-so-technical (uses tools but doesn't code)
+    - Non-technical (primarily uses reports/results)
+
+**Organizational Level**
+    - Management (decision-makers, team leads)
+    - Individual Contributor (hands-on practitioners)
+    - Executive (strategic decision-makers)
+
+**Primary Interests**
+    - License Compliance (ensuring proper license usage and attribution)
+    - Cybersecurity (vulnerability management, security scanning)
+    - Software Supply Chain (SBOM generation, dependency tracking)
+    - Research & Development (academic research, tool development)
+    - Other (specify)
+
+**Experience Level**
+    - Beginner (new to the domain)
+    - Intermediate (some experience)
+    - Advanced (expert level)
+    - Expert (deep domain knowledge)
+
+**Other Objectives**
+    Additional goals or use cases specific to this role
+
+Role Categories
+---------------
+
+Based on AboutCode's focus areas, we anticipate roles falling into these categories:
+
+**Compliance & Legal**
+    Users focused on license compliance, legal requirements, and attribution
+
+**Security & Vulnerability Management**
+    Users focused on identifying and managing security vulnerabilities
+
+**Development & Engineering**
+    Developers and engineers integrating AboutCode tools into workflows
+
+**DevOps & Operations**
+    Users managing CI/CD pipelines and operational processes
+
+**Research & Academia**
+    Researchers and students using AboutCode for academic purposes
+
+**Management & Strategy**
+    Decision-makers evaluating and implementing AboutCode solutions
+
+**Contributors & Maintainers**
+    Open source contributors and project maintainers
+
+Data Collection
+---------------
+
+We collect user role information through:
+
+1. **Slack Polling**: Regular polls in the #general channel
+2. **Community Surveys**: Periodic community-wide surveys
+3. **User Registration**: Optional role information during tool registration
+4. **Documentation Feedback**: Role identification through documentation interactions
+
+See :ref:`slack-polling-guide` for details on conducting polls in Slack.
+
+Role Examples
+-------------
+
+The following are example roles that may be common in the AboutCode community:
+
+**Open Source Compliance Manager**
+    - Job Title: Compliance Manager, Open Source Program Office Lead
+    - Professional Status: Professional
+    - Technical Level: Not-so-technical
+    - Organizational Level: Management
+    - Primary Interests: License Compliance
+    - Experience Level: Intermediate to Advanced
+    - Objectives: Ensure company compliance with open source licenses, manage attribution requirements
+
+**Security Engineer**
+    - Job Title: Security Engineer, Application Security Specialist
+    - Professional Status: Professional
+    - Technical Level: Technical
+    - Organizational Level: Individual Contributor
+    - Primary Interests: Cybersecurity
+    - Experience Level: Intermediate to Expert
+    - Objectives: Identify vulnerabilities in dependencies, manage security risks
+
+**Software Developer**
+    - Job Title: Software Engineer, Developer
+    - Professional Status: Professional
+    - Technical Level: Technical
+    - Organizational Level: Individual Contributor
+    - Primary Interests: Software Supply Chain, License Compliance
+    - Experience Level: Beginner to Advanced
+    - Objectives: Generate SBOMs, understand dependencies, ensure proper license usage
+
+**DevOps Engineer**
+    - Job Title: DevOps Engineer, Platform Engineer
+    - Professional Status: Professional
+    - Technical Level: Technical
+    - Organizational Level: Individual Contributor to Management
+    - Primary Interests: Software Supply Chain, Cybersecurity
+    - Experience Level: Intermediate to Advanced
+    - Objectives: Integrate scanning into CI/CD pipelines, automate compliance checks
+
+**Legal Counsel**
+    - Job Title: Legal Counsel, Intellectual Property Attorney
+    - Professional Status: Professional
+    - Technical Level: Non-technical
+    - Organizational Level: Management
+    - Primary Interests: License Compliance
+    - Experience Level: Advanced to Expert
+    - Objectives: Review license compatibility, advise on compliance requirements
+
+**Graduate Student**
+    - Job Title: Graduate Student, Research Assistant
+    - Professional Status: Student
+    - Technical Level: Technical
+    - Organizational Level: Individual Contributor
+    - Primary Interests: Research & Development, Software Supply Chain
+    - Experience Level: Beginner to Intermediate
+    - Objectives: Research software composition analysis, academic projects
+
+**Product Manager**
+    - Job Title: Product Manager, Technical Product Manager
+    - Professional Status: Professional
+    - Technical Level: Not-so-technical to Technical
+    - Organizational Level: Management
+    - Primary Interests: Software Supply Chain, License Compliance, Cybersecurity
+    - Experience Level: Intermediate
+    - Objectives: Evaluate tools, make procurement decisions, define requirements
+
+Using Role Information
+----------------------
+
+Role information helps us:
+
+- **Organize Documentation**: Create role-specific documentation paths
+- **Improve Onboarding**: Provide targeted getting-started guides
+- **Enhance Communication**: Tailor messages and announcements to relevant audiences
+- **Prioritize Features**: Understand which features matter most to different user groups
+- **Build Community**: Connect users with similar roles and interests
+
+Next Steps
+----------
+
+1. Conduct initial Slack poll to gather role information from current community members
+2. Analyze responses to identify common roles and patterns
+3. Create role-specific documentation sections
+4. Establish ongoing data collection processes
+5. Regularly review and update role definitions based on community feedback

--- a/slack-poll-template.md
+++ b/slack-poll-template.md
@@ -1,0 +1,43 @@
+# Quick Slack Poll Template for #general Channel
+
+Copy and paste this into your Slack #general channel:
+
+---
+
+👋 **AboutCode User Roles Survey**
+
+Hi everyone! We're working on understanding our community better to improve documentation and resources. If you have a moment, please help us by sharing your role information.
+
+**Quick Poll - React with emoji:**
+- 📋 = Compliance/Legal professional
+- 🔒 = Security/Vulnerability Management
+- 💻 = Developer/Engineer
+- ⚙️ = DevOps/Operations
+- 🎓 = Student/Researcher
+- 👔 = Management/Product
+- 🤝 = Contributor/Maintainer
+- ❓ = Other (please reply in thread)
+
+**For more detail, reply to this thread with:**
+1. **Role Name**: [e.g., "Open Source Compliance Manager"]
+2. **Job Title**: [your job title or "Student"]
+3. **Student/Professional**: [one]
+4. **Technical Level**: [Technical / Not-so-technical / Non-technical]
+5. **Management/Individual Contributor**: [one]
+6. **Interested in License Compliance?** [Yes/No]
+7. **Interested in Cybersecurity?** [Yes/No]
+8. **Experience Level**: [Beginner / Intermediate / Advanced / Expert]
+9. **Other Objectives**: [any additional goals]
+
+Your responses help us create better documentation and prioritize features that matter most to you. Thanks! 🙏
+
+---
+
+**After collecting responses (post this follow-up):**
+
+📊 Thanks to everyone who participated! We received [X] responses. This helps us understand our community composition. We'll use this information to:
+- Create role-specific documentation paths
+- Tailor getting-started guides
+- Prioritize features based on your needs
+
+Stay tuned for updates! 🎉

--- a/user-roles-collection.md
+++ b/user-roles-collection.md
@@ -1,0 +1,186 @@
+# AboutCode User Roles Collection
+
+This document provides templates and examples for collecting user role information from the AboutCode community.
+
+## Quick Collection Template
+
+Use this template when asking users to share their role information:
+
+```
+Role Name: [e.g., "Open Source Compliance Manager"]
+Job Title: [your job title]
+Student/Professional: [Student | Professional]
+Technical Level: [Technical | Not-so-technical | Non-technical]
+Management/Individual Contributor: [Management | Individual Contributor | Executive]
+Interested in License Compliance? [Yes | No]
+Interested in Cybersecurity? [Yes | No]
+Experience Level (License Compliance): [Beginner | Intermediate | Advanced | Expert]
+Experience Level (Cybersecurity): [Beginner | Intermediate | Advanced | Expert]
+Experience Level (Software Supply Chain): [Beginner | Intermediate | Advanced | Expert]
+Other Objectives: [any additional goals or use cases]
+Preferred AboutCode Tools: [list tools you use]
+```
+
+## Slack Poll Examples
+
+### Simple Emoji Reaction Poll
+
+```
+👋 Quick poll: What's your primary role with AboutCode?
+
+React with:
+📋 = Compliance/Legal
+🔒 = Security/Vulnerability Management  
+💻 = Developer/Engineer
+⚙️ = DevOps/Operations
+🎓 = Student/Researcher
+👔 = Management/Product
+🤝 = Contributor/Maintainer
+❓ = Other (reply in thread)
+```
+
+### Detailed Thread Response Poll
+
+```
+📊 AboutCode User Roles Survey
+
+We're building a user roles framework. Please reply with:
+
+1. Role Name: [descriptive name]
+2. Job Title: [your title]
+3. Student/Professional: [one]
+4. Technical Level: [Technical / Not-so-technical / Non-technical]
+5. Management/Individual Contributor: [one]
+6. Interested in License Compliance? [Yes/No]
+7. Interested in Cybersecurity? [Yes/No]
+8. Experience Level: [Beginner / Intermediate / Advanced / Expert]
+9. Other Objectives: [any additional goals]
+
+Thanks! 🙏
+```
+
+## Example Responses
+
+### Example 1: Compliance Manager
+
+```
+Role Name: Open Source Compliance Manager
+Job Title: Compliance Manager
+Student/Professional: Professional
+Technical Level: Not-so-technical
+Management/Individual Contributor: Management
+Interested in License Compliance? Yes
+Interested in Cybersecurity? No
+Experience Level (License Compliance): Advanced
+Experience Level (Cybersecurity): Beginner
+Experience Level (Software Supply Chain): Intermediate
+Other Objectives: Ensure company compliance with open source licenses, manage attribution requirements
+Preferred AboutCode Tools: scancode.io, dejacode, scancode-workbench
+```
+
+### Example 2: Security Engineer
+
+```
+Role Name: Security Engineer
+Job Title: Application Security Specialist
+Student/Professional: Professional
+Technical Level: Technical
+Management/Individual Contributor: Individual Contributor
+Interested in License Compliance? No
+Interested in Cybersecurity? Yes
+Experience Level (License Compliance): Beginner
+Experience Level (Cybersecurity): Expert
+Experience Level (Software Supply Chain): Advanced
+Other Objectives: Identify vulnerabilities in dependencies, manage security risks
+Preferred AboutCode Tools: vulnerablecode, scancode.io
+```
+
+### Example 3: Graduate Student
+
+```
+Role Name: Research Student
+Job Title: Graduate Student
+Student/Professional: Student
+Technical Level: Technical
+Management/Individual Contributor: Individual Contributor
+Interested in License Compliance? Yes
+Interested in Cybersecurity? Yes
+Experience Level (License Compliance): Beginner
+Experience Level (Cybersecurity): Beginner
+Experience Level (Software Supply Chain): Intermediate
+Other Objectives: Research software composition analysis, academic projects
+Preferred AboutCode Tools: scancode-toolkit, vulnerablecode
+```
+
+## Data Collection Methods
+
+### 1. Slack Polling
+- Use emoji reactions for quick polls
+- Use thread responses for detailed information
+- Post in #general channel during active hours
+- Follow up with results and next steps
+
+### 2. Google Forms Survey
+Create a form with the following sections:
+- Basic Information (Role Name, Job Title)
+- Professional Status
+- Technical Level
+- Organizational Level
+- Interests (License Compliance, Cybersecurity)
+- Experience Levels
+- Preferred Tools
+- Use Cases
+
+### 3. User Registration
+Include optional role information fields during tool registration or account creation.
+
+### 4. Documentation Feedback
+Ask users to identify their role when providing documentation feedback.
+
+## Analysis Template
+
+After collecting responses, analyze them using this structure:
+
+```markdown
+## Role Distribution
+
+- Compliance/Legal: X users
+- Security/Vulnerability Management: X users
+- Developer/Engineer: X users
+- DevOps/Operations: X users
+- Student/Researcher: X users
+- Management/Product: X users
+- Contributor/Maintainer: X users
+- Other: X users
+
+## Technical Level Distribution
+
+- Technical: X users
+- Not-so-technical: X users
+- Non-technical: X users
+
+## Interest Distribution
+
+- License Compliance: X users
+- Cybersecurity: X users
+- Both: X users
+
+## Common Use Cases
+
+1. [Use case 1]
+2. [Use case 2]
+3. [Use case 3]
+
+## Insights
+
+[Key insights from the data]
+```
+
+## Next Steps
+
+1. Conduct initial Slack poll
+2. Collect responses for 1-2 weeks
+3. Analyze results
+4. Update user roles framework documentation
+5. Create role-specific documentation sections
+6. Establish ongoing collection process

--- a/user-roles-template.json
+++ b/user-roles-template.json
@@ -1,0 +1,41 @@
+{
+  "user_role_template": {
+    "role_name": "Example: Open Source Compliance Manager",
+    "job_title": "Example: Compliance Manager, Open Source Program Office Lead",
+    "professional_status": "student | professional",
+    "technical_level": "technical | not-so-technical | non-technical",
+    "organizational_level": "management | individual_contributor | executive",
+    "primary_interests": {
+      "license_compliance": true,
+      "cybersecurity": false,
+      "software_supply_chain": true,
+      "research_development": false,
+      "other": "Specify other objectives here"
+    },
+    "experience_level": {
+      "license_compliance": "beginner | intermediate | advanced | expert",
+      "cybersecurity": "beginner | intermediate | advanced | expert",
+      "software_supply_chain": "beginner | intermediate | advanced | expert"
+    },
+    "other_objectives": "Additional goals or use cases specific to this role",
+    "preferred_aboutcode_tools": [
+      "scancode-toolkit",
+      "scancode.io",
+      "vulnerablecode",
+      "dejacode",
+      "scancode-workbench",
+      "other"
+    ],
+    "use_cases": [
+      "Example: Generate SBOMs for compliance",
+      "Example: Scan dependencies for vulnerabilities",
+      "Example: Review license compatibility"
+    ]
+  },
+  "collection_metadata": {
+    "collected_via": "slack | survey | registration | other",
+    "collection_date": "YYYY-MM-DD",
+    "collector": "Name or identifier of person collecting",
+    "notes": "Any additional notes about this role"
+  }
+}


### PR DESCRIPTION
## Overview
This PR introduces a framework for defining **AboutCode User Roles**. Our goal is to identify the specific needs of our community members so we can provide more efficient documentation and tooling.

## User Attributes
We are defining roles based on the following criteria:
* **Professional Status:** Student vs. Professional.
* **Technical Depth:** Technical vs. Non-technical (Management/Legal).
* **Domain Focus:** License Compliance and/or Cybersecurity.
* **Experience:** Expertise level in SCA and related domains.

## Goal
Establishing these roles allows us to:
1.  **Poll the Community:** Use these definitions to initiate a survey in the Slack `#general` channel.
2.  **Tailor Information:** Ensure that "not-so-technical" users get the high-level overviews they need, while "technical" users get deep-dive documentation.
3.  **Bridge Knowledge Gaps:** Identify who is using our tools and why, especially those in the Slack channel we don't know much about yet.

## Next Steps
- [ ] Merge this persona framework.
- [ ] Initiate the Slack polling process to gather real-world user data.