### PR TITLE
Fix sidebar home button link (Issue #248)

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,8 +1,29 @@
 {% extends "!layout.html" %}
 
-  {% block menu %}
-    {{ super() }}
-    <div class="toc-index-div">
-        <a href="{{pathto('genindex.html', 1)}}" class="reference internal toc-index">Index</a>
-    </div>
-  {% endblock %}
+{%- block sidebartitle %}
+{%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
+<a href="https://aboutcode.org" class="icon icon-home">
+  {% if not theme_logo_only %}{{ project }}{% endif %}
+  {%- if logo or logo_url %}
+  <img src="{{ _logo_url }}" class="logo" alt="{{ _('Logo') }}" />
+  {%- endif %}
+</a>
+
+{%- if READTHEDOCS or DEBUG %}
+{%- if theme_version_selector or theme_language_selector %}
+<div class="switch-menus">
+  <div class="version-switch"></div>
+  <div class="language-switch"></div>
+</div>
+{%- endif %}
+{%- endif %}
+
+{%- include "searchbox.html" %}
+{%- endblock %}
+
+{% block menu %}
+{{ super() }}
+<div class="toc-index-div">
+  <a href="{{pathto('genindex.html', 1)}}" class="reference internal toc-index">Index</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
Fixes #248.

Updates the sidebar home button/logo to link to `https://aboutcode.org` instead of the documentation root.

Verified by building docs locally and checking the link.