### PR TITLE
Fix github_user in docs config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,7 +79,7 @@ master_doc = "index"
 
 html_context = {
     "display_github": True,
-    "github_user": "nexB",
+    "github_user": "aboutcode-org",
     "github_repo": "aboutcode",
     "github_version": "master",  # branch
     "conf_py_path": "/docs/source/",  # path in the checkout to the docs root


### PR DESCRIPTION
Fixes #255

Updated the github_user from nexB to aboutcode-org in docs/source/conf.py so the Edit on GitHub links point to the right repo.

Tested locally with `make docs` - build passes without errors.