### PR TITLE
Cleanup: remove duplicate dist entry in pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ norecursedirs = [
    "dist",
    "build",
    "_build",
-   "dist",
    "etc",
    "local",
    "ci",


### PR DESCRIPTION
Fixes: N/A (small cleanup change)

Removed a duplicate `dist` entry from `pyproject.toml` under `[tool.pytest.ini_options].norecursedirs`.

### Tasks
* [x] PR is descriptively titled and links the original issue above (N/A)
* [ ] Tests pass
* [x] Commits are in uniquely-named feature branch and has no merge conflicts
