### PR TITLE
fix: improve UI padding and text alignment between navbar and content

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -2,7 +2,7 @@
 .wy-nav-content {
     max-width: 100%;
     padding: 0px 40px 0px 0px;
-    margin-top: 0px;
+    margin-top: 20px;
 }
 
 .wy-nav-content-wrap {
@@ -12,16 +12,18 @@
 div.rst-content {
     max-width: 1300px;
     border: 0;
-    padding: 10px 80px 10px 80px;
+    padding: 30px 80px 10px 80px;
     margin-left: 50px;
+    line-height: 1.6;
 }
 
 @media (max-width: 768px) {
     div.rst-content {
         max-width: 1300px;
         border: 0;
-        padding: 0px 10px 10px 10px;
+        padding: 20px 10px 10px 10px;
         margin-left: 0px;
+        line-height: 1.5;
     }
 }
 


### PR DESCRIPTION
Fixes #235

## Summary
This PR addresses the UI/UX issue where the documentation had insufficient padding between the navbar and content text, making the text appear cramped and hard to read.

## Changes
- Increased top margin in .wy-nav-content from 0px to 20px for better spacing from navbar
- Increased top padding in div.rst-content from 10px to 30px for improved text visibility  
- Added line-height: 1.6 for better text readability on desktop
- Improved mobile responsive padding from 0px to 20px with line-height: 1.5

## Testing
- ✅ Built documentation locally with no errors
- ✅ Verified visual improvements in browser
- ✅ Tested responsive design on mobile breakpoint
- ✅ Confirmed no layout breaks or overlapping elements

## Screenshots
The changes provide better spacing and improved readability throughout the documentation.