### PR TITLE
Fix heading structure in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,9 +27,9 @@ Overview
 
    aboutcode-project-overview
 
-************
+------------
 Contributing
-************
+------------
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION
This PR fixes the heading structure in docs/source/index.rst to follow proper restructured Text Formatting.
It resolves incorrect top-level heading usage and ensures consistent section hierarchy for better documentation rendering.
