### PR TITLE
docs: add persona audit, sitemap proposal, and user journeys (closes …

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-design

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,12 @@
+# Documentation build requirements
+# Note: ReadTheDocs installs from setup.cfg [options.extras_require] docs section
+# This file is provided for local development convenience
+
+Sphinx>=4.0
+sphinx-rtd-theme
+sphinx-reredirects
 sphinx-design
+doc8
+sphinx-autobuild
+sphinx-rtd-dark-mode
+sphinx-copybutton

--- a/docs/source/_static/images/dejacode-icon.svg
+++ b/docs/source/_static/images/dejacode-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" fill="#27AE60" rx="10"/>
+  <text x="100" y="90" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="white" text-anchor="middle">DejaCode</text>
+  <rect x="60" y="110" width="80" height="60" fill="none" stroke="white" stroke-width="3" rx="5"/>
+  <circle cx="80" cy="130" r="4" fill="white"/>
+  <circle cx="100" cy="130" r="4" fill="white"/>
+  <circle cx="120" cy="130" r="4" fill="white"/>
+  <rect x="75" y="145" width="50" height="3" fill="white"/>
+  <rect x="75" y="155" width="40" height="3" fill="white"/>
+</svg>

--- a/docs/source/_static/images/purldb-icon.svg
+++ b/docs/source/_static/images/purldb-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" fill="#9B59B6" rx="10"/>
+  <text x="100" y="90" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">PurlDB</text>
+  <circle cx="70" cy="130" r="15" fill="none" stroke="white" stroke-width="3"/>
+  <circle cx="100" cy="130" r="15" fill="none" stroke="white" stroke-width="3"/>
+  <circle cx="130" cy="130" r="15" fill="none" stroke="white" stroke-width="3"/>
+  <line x1="85" y1="130" x2="85" y2="130" stroke="white" stroke-width="3"/>
+  <line x1="115" y1="130" x2="115" y2="130" stroke="white" stroke-width="3"/>
+</svg>

--- a/docs/source/_static/images/scancode-icon.svg
+++ b/docs/source/_static/images/scancode-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" fill="#4A90E2" rx="10"/>
+  <text x="100" y="75" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">ScanCode</text>
+  <text x="100" y="100" font-family="Arial, sans-serif" font-size="18" fill="white" text-anchor="middle">Toolkit</text>
+  <rect x="60" y="120" width="80" height="10" fill="white" rx="2"/>
+  <rect x="60" y="140" width="60" height="10" fill="white" rx="2"/>
+  <rect x="60" y="160" width="70" height="10" fill="white" rx="2"/>
+</svg>

--- a/docs/source/_static/images/scancodeio-icon.svg
+++ b/docs/source/_static/images/scancodeio-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" fill="#0066cc" rx="10"/>
+  <text x="100" y="90" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="white" text-anchor="middle">ScanCode.io</text>
+  <circle cx="100" cy="130" r="25" fill="none" stroke="white" stroke-width="3"/>
+  <path d="M 85 130 L 95 140 L 115 120" fill="none" stroke="white" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/docs/source/_static/images/vulnerablecode-icon.svg
+++ b/docs/source/_static/images/vulnerablecode-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" fill="#E74C3C" rx="10"/>
+  <text x="100" y="75" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white" text-anchor="middle">VulnerableCode</text>
+  <path d="M 100 90 L 130 130 L 100 170 L 70 130 Z" fill="none" stroke="white" stroke-width="4"/>
+  <text x="100" y="140" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle">!</text>
+</svg>

--- a/docs/source/_static/images/workbench-icon.svg
+++ b/docs/source/_static/images/workbench-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" fill="#34495E" rx="10"/>
+  <text x="100" y="70" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white" text-anchor="middle">ScanCode</text>
+  <text x="100" y="92" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white" text-anchor="middle">Workbench</text>
+  <rect x="50" y="110" width="100" height="70" fill="none" stroke="white" stroke-width="3" rx="3"/>
+  <rect x="50" y="110" width="100" height="25" fill="white" opacity="0.3" rx="3"/>
+  <line x1="65" y1="145" x2="95" y2="145" stroke="white" stroke-width="2"/>
+  <line x1="65" y1="155" x2="115" y2="155" stroke="white" stroke-width="2"/>
+  <line x1="65" y1="165" x2="85" y2="165" stroke="white" stroke-width="2"/>
+</svg>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,6 +28,7 @@ author = "AboutCode.org authors and contributors"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx_design",
     "sphinx.ext.intersphinx",
     "sphinx_reredirects",
     "sphinx_rtd_theme",

--- a/docs/source/developer/getting-started.rst
+++ b/docs/source/developer/getting-started.rst
@@ -1,0 +1,345 @@
+.. _developer_getting_started:
+
+##########################################
+Getting Started: Developer & Integrator
+##########################################
+
+This guide shows you how to integrate AboutCode tools into your development workflow, automate scanning in CI/CD pipelines, and use APIs for programmatic access. You'll learn the fundamentals of building automated compliance and security workflows using AboutCode's suite of open source tools.
+
+************
+Prerequisites
+************
+
+Before you begin, ensure you have:
+
+- Development environment with Python 3.8+, Node.js, or Java (depending on your project)
+- Access to your CI/CD system (GitHub Actions, GitLab CI, Jenkins, etc.)
+- Basic understanding of REST APIs and command-line tools
+- Familiarity with your build and deployment process
+
+
+******************
+Quick Start Path
+******************
+
+Step 1: Install Command-Line Tools
+===================================
+
+**ScanCode Toolkit**
+
+.. code-block:: bash
+
+   pip install scancode-toolkit
+   
+   # Verify installation
+   scancode --version
+
+**VulnerableCode CLI (optional)**
+
+.. code-block:: bash
+
+   pip install vulnerablecode
+   
+   # Configure API endpoint
+   export VULNERABLECODE_URL="https://public.vulnerablecode.io"
+
+For detailed installation options, see :doc:`../aboutcode-projects/scancode-toolkit-project`.
+
+
+Step 2: Run a Command-Line Scan
+================================
+
+Scan your project directory to generate structured output:
+
+.. code-block:: bash
+
+   # Full scan with JSON output
+   scancode --license --copyright --package --info \
+            --json-pp output.json \
+            /path/to/your/project
+   
+   # Quick scan for licenses only
+   scancode --license --json-pp licenses.json /path/to/your/project
+   
+   # Generate SPDX SBOM
+   scancode --spdx output.spdx /path/to/your/project
+
+**Output Formats:**
+
+- ``--json`` or ``--json-pp`` - JSON (pretty-printed)
+- ``--spdx`` - SPDX format SBOM
+- ``--cyclonedx`` - CycloneDX format SBOM
+- ``--csv`` - CSV for spreadsheet analysis
+- ``--html`` - HTML report for human review
+
+
+Step 3: Integrate with CI/CD
+=============================
+
+**GitHub Actions Example**
+
+Create ``.github/workflows/scancode.yml``:
+
+.. code-block:: yaml
+
+   name: License and Security Scan
+   
+   on: [push, pull_request]
+   
+   jobs:
+     scan:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v3
+         
+         - name: Run ScanCode
+           uses: aboutcode-org/scancode-action@v1
+           with:
+             path: '.'
+             output: 'scancode-results.json'
+         
+         - name: Upload results
+           uses: actions/upload-artifact@v3
+           with:
+             name: scancode-results
+             path: scancode-results.json
+         
+         - name: Check for license issues
+           run: |
+             python scripts/check-licenses.py scancode-results.json
+
+See :doc:`../aboutcode-projects/scancode-action-project` for more GitHub Actions options.
+
+
+**GitLab CI Example**
+
+Add to ``.gitlab-ci.yml``:
+
+.. code-block:: yaml
+
+   scan_licenses:
+     image: python:3.11
+     stage: test
+     script:
+       - pip install scancode-toolkit
+       - scancode --license --json-pp results.json .
+       - python scripts/validate-licenses.py results.json
+     artifacts:
+       paths:
+         - results.json
+       expire_in: 1 week
+
+
+**Jenkins Pipeline Example**
+
+.. code-block:: groovy
+
+   pipeline {
+       agent any
+       stages {
+           stage('License Scan') {
+               steps {
+                   sh 'pip install scancode-toolkit'
+                   sh 'scancode --license --json results.json .'
+                   archiveArtifacts artifacts: 'results.json'
+               }
+           }
+       }
+   }
+
+
+Step 4: Use REST APIs
+======================
+
+**ScanCode.io API**
+
+Programmatically create projects and retrieve scan results:
+
+.. code-block:: python
+
+   import requests
+   
+   SCANCODEIO_URL = "https://your-scancodeio-instance.com"
+   API_KEY = "your-api-key"
+   
+   headers = {"Authorization": f"Token {API_KEY}"}
+   
+   # Create a project
+   response = requests.post(
+       f"{SCANCODEIO_URL}/api/projects/",
+       headers=headers,
+       json={
+           "name": "my-project",
+           "input_urls": ["https://example.com/package.tar.gz"]
+       }
+   )
+   project_uuid = response.json()['uuid']
+   
+   # Run a pipeline
+   requests.post(
+       f"{SCANCODEIO_URL}/api/projects/{project_uuid}/pipelines/",
+       headers=headers,
+       json={"pipeline": "scan_codebase"}
+   )
+   
+   # Get results
+   results = requests.get(
+       f"{SCANCODEIO_URL}/api/projects/{project_uuid}/results/",
+       headers=headers
+   ).json()
+
+**VulnerableCode API**
+
+Query vulnerability data:
+
+.. code-block:: python
+
+   import requests
+   
+   # Search for vulnerabilities by package
+   response = requests.get(
+       'https://public.vulnerablecode.io/api/packages',
+       params={'purl': 'pkg:npm/express@4.17.1'}
+   )
+   
+   package_data = response.json()['results'][0]
+   vulnerabilities = package_data['affected_by_vulnerabilities']
+   
+   # Get vulnerability details
+   for vuln in vulnerabilities:
+       vuln_response = requests.get(
+           f"https://public.vulnerablecode.io{vuln['url']}"
+       )
+       details = vuln_response.json()
+       print(f"CVE: {details['vulnerability_id']}")
+       print(f"Severity: {details.get('severity', 'Unknown')}")
+
+For complete API documentation, see :doc:`../aboutcode-projects/scancodeio-project` and :doc:`../aboutcode-projects/vulnerablecode-project`.
+
+
+Step 5: Process and Filter Results
+===================================
+
+**Parse JSON Output**
+
+.. code-block:: python
+
+   import json
+   
+   with open('scancode-results.json', 'r') as f:
+       data = json.load(f)
+   
+   # Extract all detected licenses
+   licenses = set()
+   for file in data['files']:
+       if file.get('licenses'):
+           for lic in file['licenses']:
+               licenses.add(lic['key'])
+   
+   print(f"Detected licenses: {', '.join(sorted(licenses))}")
+   
+   # Find GPL-licensed files
+   gpl_files = []
+   for file in data['files']:
+       if file.get('licenses'):
+           for lic in file['licenses']:
+               if 'gpl' in lic['key'].lower():
+                   gpl_files.append(file['path'])
+   
+   if gpl_files:
+       print(f"Warning: GPL license found in {len(gpl_files)} files")
+       for path in gpl_files[:5]:  # Show first 5
+           print(f"  - {path}")
+
+
+**Filter by License Policy**
+
+.. code-block:: python
+
+   APPROVED_LICENSES = {'mit', 'apache-2.0', 'bsd-3-clause', 'bsd-2-clause'}
+   FLAGGED_LICENSES = {'gpl-2.0', 'gpl-3.0', 'agpl-3.0'}
+   
+   violations = []
+   for file in data['files']:
+       if file.get('licenses'):
+           for lic in file['licenses']:
+               if lic['key'] in FLAGGED_LICENSES:
+                   violations.append({
+                       'file': file['path'],
+                       'license': lic['key']
+                   })
+   
+   if violations:
+       print(f"ERROR: Found {len(violations)} license policy violations")
+       exit(1)
+
+
+***************
+Next Steps
+***************
+
+**Advanced Integration**
+
+- Build custom ScanCode.io pipelines for specialized workflows
+- Create pre-commit hooks for local scanning before push
+- Integrate with issue tracking systems (JIRA, GitHub Issues)
+- Set up automated SBOM generation and distribution
+- Implement continuous vulnerability monitoring
+
+**Scaling and Performance**
+
+- Run distributed scans for large codebases
+- Cache scan results to avoid redundant scanning
+- Use incremental scanning for changed files only
+- Deploy ScanCode.io for enterprise-scale automation
+
+**Custom Development**
+
+- Extend ScanCode with custom plugins
+- Create license detection rules for proprietary licenses
+- Build custom output formatters and reporters
+- Develop organization-specific policy enforcement tools
+
+
+**Tools and Documentation**
+
+- :doc:`../aboutcode-projects/scancode-toolkit-project` - Full CLI reference
+- :doc:`../aboutcode-projects/scancodeio-project` - API and pipeline development
+- :doc:`../aboutcode-projects/scancode-action-project` - GitHub Actions integration
+- :doc:`../aboutcode-projects/vulnerablecode-project` - Vulnerability API
+- :doc:`../contributing` - Contributing to AboutCode projects
+
+
+******************
+Common Questions
+******************
+
+**How long does scanning take?**
+
+Scan time depends on codebase size. Small projects (< 1000 files) take seconds to minutes. Large codebases (100k+ files) may take hours. Use ``--max-depth`` to limit recursion or ``--ignore`` to skip directories like ``node_modules/``.
+
+**Can I scan private/proprietary code?**
+
+Yes, all AboutCode tools run locally or on your infrastructure. Code is not sent to external services unless you explicitly upload to a hosted instance you control.
+
+**How do I handle binary files?**
+
+ScanCode extracts archives and can scan inside many binary formats. For compiled binaries, focus on dependency manifests and SBOM generation during the build process.
+
+**How do I customize license detection?**
+
+Create custom license rules using ScanCode's license library format. See the ScanCode documentation for adding proprietary or organization-specific licenses.
+
+**Can I integrate with Slack/Teams for alerts?**
+
+Yes, use webhooks in your CI/CD pipeline to send notifications. Parse scan results and post messages when policy violations or vulnerabilities are detected.
+
+
+******************
+Getting Help
+******************
+
+- Community chat: `Gitter <https://gitter.im/aboutcode-org/discuss>`_ or `Slack <https://join.slack.com/t/aboutcode-org/shared_invite/zt-1paqwxccw-IuafuiAvYJFkTqGaZsC1og>`_
+- GitHub issues: Report bugs or request features on project repositories
+- API documentation: Check project-specific docs for detailed API references
+- Code examples: Browse example integrations in project repositories

--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -1,0 +1,128 @@
+.. _developer_index:
+
+########################################
+Developer & Integrator Documentation
+########################################
+
+Welcome to the Developer and Integrator's guide for AboutCode tools. This section helps you integrate license scanning and vulnerability detection into your build pipelines, automate compliance workflows, and use AboutCode APIs programmatically. Whether you're building CI/CD integrations, custom analysis tools, or automated reporting systems, you'll find the technical documentation and examples you need here.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Developer Guides
+
+   getting-started
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Quick Access
+
+   ../getting-started/start-scanning-code
+   ../getting-started/create-sboms
+
+
+----
+
+*******************
+Integration Guides
+*******************
+
+**CI/CD Integration**
+
+Integrate AboutCode tools into GitHub Actions, GitLab CI, Jenkins, Azure Pipelines, and other CI/CD platforms. Automate license scanning and vulnerability detection as part of your build and deployment process.
+
+**REST APIs**
+
+Use AboutCode REST APIs for programmatic access to scanning results, vulnerability data, and package information. Build custom dashboards, reporting tools, and integration workflows.
+
+**Command-Line Tools**
+
+Master the command-line interfaces for ScanCode Toolkit, VulnerableCode CLI, and other AboutCode tools. Script automated workflows and batch processing tasks.
+
+
+----
+
+**********************
+Development Workflows
+**********************
+
+**Automated Scanning**
+
+Set up pre-commit hooks, pull request checks, and scheduled scans. Fail builds when license policy violations or critical vulnerabilities are detected.
+
+**Custom Pipelines**
+
+Build custom analysis pipelines using ScanCode.io's plugin architecture. Extend functionality with your own scanning rules, data enrichment, and output formats.
+
+**Data Integration**
+
+Export scan results to SIEM systems, issue trackers (JIRA, GitHub Issues), vulnerability management platforms, and compliance reporting tools.
+
+
+----
+
+************************
+Code Examples & SDKs
+************************
+
+**Python Integration**
+
+.. code-block:: python
+
+   from scancode import cli
+   
+   # Programmatic scanning
+   results = cli.run_scan(
+       input_path='/path/to/code',
+       license=True,
+       copyright=True,
+       package=True
+   )
+
+**GitHub Actions**
+
+.. code-block:: yaml
+
+   - name: ScanCode Scan
+     uses: aboutcode-org/scancode-action@v1
+     with:
+       path: '.'
+       output: 'scancode-results.json'
+
+**REST API Client**
+
+.. code-block:: python
+
+   import requests
+   
+   # Query VulnerableCode
+   response = requests.get(
+       'https://public.vulnerablecode.io/api/packages',
+       params={'purl': 'pkg:npm/lodash@4.17.15'}
+   )
+   vulnerabilities = response.json()
+
+
+----
+
+*******************
+Related Resources
+*******************
+
+- :doc:`../aboutcode-projects/scancode-toolkit-project` - CLI documentation and API
+- :doc:`../aboutcode-projects/scancodeio-project` - REST API and pipeline development
+- :doc:`../aboutcode-projects/scancode-action-project` - GitHub Actions integration
+- :doc:`../aboutcode-projects/vulnerablecode-project` - Vulnerability API reference
+- :doc:`../aboutcode-projects/purldb-project` - Package metadata API
+
+
+----
+
+**********************
+Contributing to Tools
+**********************
+
+AboutCode tools are open source and welcome contributions. Whether you're fixing bugs, adding features, improving documentation, or creating plugins, check out:
+
+- :doc:`../contributing` - General contribution guidelines
+- Individual project GitHub repositories for issue tracking
+- Community channels for discussion and support

--- a/docs/source/index-new-persona-based.rst
+++ b/docs/source/index-new-persona-based.rst
@@ -1,0 +1,291 @@
+.. _aboutcode_home:
+
+#########
+AboutCode
+#########
+
+Welcome to AboutCode! We provide free and open source tools to help you understand
+what's in your software: where it comes from, what licenses apply, and whether it
+has known security issues. Whether you're managing legal compliance, securing your
+supply chain, or building software, AboutCode has tools to help.
+
+
+.. _who_are_you:
+
+*************
+Who are you?
+*************
+
+Choose your path to get started quickly with the tools and guides most relevant to you.
+
+.. grid:: 1 2 3 3
+    :gutter: 3
+    :padding: 2
+
+    .. grid-item-card:: 👔 Compliance Officer
+        :link: legal/getting-started
+        :link-type: doc
+        :class-card: sd-text-center sd-font-weight-bold
+        :class-title: sd-fs-5
+        :shadow: md
+
+        Manage open source licenses, create SBOMs, and ensure your organization
+        meets its legal obligations.
+
+        **Get Started →**
+
+        +++
+        License scanning • Policy enforcement • Attribution • SBOM generation
+
+    .. grid-item-card:: 🔒 Security Researcher
+        :link: security/getting-started
+        :link-type: doc
+        :class-card: sd-text-center sd-font-weight-bold
+        :class-title: sd-fs-5
+        :shadow: md
+
+        Find vulnerabilities in your dependencies, analyze software composition,
+        and secure your supply chain.
+
+        **Get Started →**
+
+        +++
+        Vulnerability scanning • SBOM analysis • Dependency tracking • Risk assessment
+
+    .. grid-item-card:: 💻 Developer/Integrator
+        :link: developer/getting-started
+        :link-type: doc
+        :class-card: sd-text-center sd-font-weight-bold
+        :class-title: sd-fs-5
+        :shadow: md
+
+        Integrate AboutCode tools into your build pipeline, automate scans,
+        and use our APIs.
+
+        **Get Started →**
+
+        +++
+        CLI tools • CI/CD integration • REST APIs • Custom pipelines
+
+
+----
+
+.. _quick_links:
+
+************
+Quick Links
+************
+
+Not sure where to start? Here are some popular tasks:
+
+.. grid:: 1 2 2 2
+    :gutter: 2
+
+    .. grid-item-card:: 📋 Create an SBOM
+        :link: getting-started/create-sboms
+        :link-type: doc
+
+        Generate Software Bill of Materials in SPDX or CycloneDX format
+
+    .. grid-item-card:: 🔍 Scan for Licenses
+        :link: getting-started/start-scanning-code
+        :link-type: doc
+
+        Identify licenses and copyrights in your codebase
+
+    .. grid-item-card:: 🛡️ Find Vulnerabilities
+        :link: security/quickstart/first-vulnerability-scan
+        :link-type: doc
+
+        Discover known security issues in your dependencies
+
+    .. grid-item-card:: ⚖️ Set License Policies
+        :link: getting-started/manage-license-policies
+        :link-type: doc
+
+        Define which licenses are approved for your organization
+
+
+----
+
+.. _aboutcode_projects:
+
+******************
+AboutCode Projects
+******************
+
+AboutCode is a family of tools that work together:
+
+.. grid:: 1 1 2 2
+    :gutter: 3
+
+    .. grid-item-card:: ScanCode.io
+        :link: aboutcode-projects/scancodeio-project
+        :link-type: doc
+        :img-top: _static/images/scancodeio-icon.svg
+        :img-alt: ScanCode.io
+
+        Automated pipeline platform for scanning packages, containers, and codebases
+        at scale.
+
+    .. grid-item-card:: ScanCode Toolkit
+        :link: aboutcode-projects/scancode-toolkit-project
+        :link-type: doc
+        :img-top: _static/images/scancode-icon.svg
+        :img-alt: ScanCode Toolkit
+
+        Command-line tool to detect licenses, copyrights, and dependencies in your code.
+
+    .. grid-item-card:: VulnerableCode
+        :link: aboutcode-projects/vulnerablecode-project
+        :link-type: doc
+        :img-top: _static/images/vulnerablecode-icon.svg
+        :img-alt: VulnerableCode
+
+        Open database of software vulnerabilities with tools to track and correlate CVEs.
+
+    .. grid-item-card:: DejaCode
+        :link: aboutcode-projects/dejacode-project
+        :link-type: doc
+        :img-top: _static/images/dejacode-icon.svg
+        :img-alt: DejaCode
+
+        Enterprise compliance platform for managing software inventories and policies.
+
+    .. grid-item-card:: PurlDB
+        :link: aboutcode-projects/purldb-project
+        :link-type: doc
+        :img-top: _static/images/purldb-icon.svg
+        :img-alt: PurlDB
+
+        Database of Package URLs (PURLs) with package metadata and matching capabilities.
+
+    .. grid-item-card:: ScanCode Workbench
+        :link: aboutcode-projects/scancode-workbench-project
+        :link-type: doc
+        :img-top: _static/images/workbench-icon.svg
+        :img-alt: ScanCode Workbench
+
+        Desktop application to review scan results and document your conclusions.
+
+.. button-link:: aboutcode-project-overview.html
+    :color: primary
+    :outline:
+
+    View All Projects
+
+
+----
+
+.. _explore_documentation:
+
+*********************
+Explore Documentation
+*********************
+
+.. toctree::
+   :maxdepth: 1
+   :caption: By Role
+
+   legal/index
+   security/index
+   developer/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Getting Started
+
+   getting-started/start-scanning-code
+   getting-started/create-sboms
+   getting-started/consume-sboms
+   getting-started/manage-license-policies
+   getting-started/cra-compliance
+
+.. toctree::
+   :maxdepth: 2
+   :caption: All Projects
+
+   aboutcode-project-overview
+   aboutcode-projects/scancodeio-project
+   aboutcode-projects/scancode-toolkit-project
+   aboutcode-projects/vulnerablecode-project
+   aboutcode-projects/dejacode-project
+   aboutcode-projects/purldb-project
+   aboutcode-projects/scancode-workbench-project
+   aboutcode-projects/license-expression-project
+   aboutcode-projects/scancode-licensedb-project
+   aboutcode-projects/source-inspector-project
+   aboutcode-projects/python-inspector-project
+   aboutcode-projects/scancode-action-project
+   aboutcode-projects/aboutcode-toolkit-project
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Data & Standards
+
+   aboutcode-data/abcd
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contributing
+
+   contributing
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Community & Archive
+
+   archive
+   license
+
+
+----
+
+.. _need_help:
+
+*********
+Need Help?
+*********
+
+.. grid:: 1 2 2 2
+    :gutter: 2
+
+    .. grid-item::
+        :columns: 12 6 6 6
+
+        **💬 Chat with Us**
+
+        Join our community on `Gitter <https://gitter.im/aboutcode-org/discuss>`_
+        or `Slack <https://join.slack.com/t/aboutcode-org/shared_invite/zt-1paqwxccw-IuafuiAvYJFkTqGaZsC1og>`_
+
+    .. grid-item::
+        :columns: 12 6 6 6
+
+        **🐛 Report Issues**
+
+        Found a bug? `Open an issue <https://github.com/aboutcode-org/>`_ on
+        the relevant project repository
+
+    .. grid-item::
+        :columns: 12 6 6 6
+
+        **📚 Browse Code**
+
+        Explore our projects at `github.com/aboutcode-org <https://github.com/aboutcode-org/>`_
+
+    .. grid-item::
+        :columns: 12 6 6 6
+
+        **🎓 Learn More**
+
+        Visit `AboutCode.org <https://www.aboutcode.org/>`_ for news, events,
+        and community resources
+
+
+.. note::
+   **New to Software Composition Analysis?**
+
+   Software Composition Analysis (SCA) helps you understand what open source
+   components are in your software, their licenses, and any security vulnerabilities.
+   Think of it as creating a detailed ingredient list for your software, so you
+   can make informed decisions about what you use and how you use it.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ Overview
 .. toctree::
    :maxdepth: 3
 
+   index-new-persona-based
    aboutcode-project-overview
 
 ************

--- a/docs/source/legal/getting-started.rst
+++ b/docs/source/legal/getting-started.rst
@@ -1,0 +1,121 @@
+.. _legal_getting_started:
+
+####################################
+Getting Started: Compliance Officer
+####################################
+
+This guide walks you through the essential steps to begin using AboutCode tools for license compliance and SBOM management. You'll learn how to perform your first license scan, understand the results, and integrate compliance workflows into your organization's processes.
+
+************
+Prerequisites
+************
+
+Before you begin, ensure you have:
+
+- Access to your organization's codebase or software packages
+- Basic familiarity with command-line tools or web interfaces
+- Understanding of your organization's license policy requirements
+- Permission to scan and analyze software components
+
+
+******************
+Quick Start Path
+******************
+
+Step 1: Install ScanCode Toolkit
+=================================
+
+Start with ScanCode Toolkit for command-line license scanning:
+
+.. code-block:: bash
+
+   pip install scancode-toolkit
+
+For detailed installation instructions, see :doc:`../aboutcode-projects/scancode-toolkit-project`.
+
+
+Step 2: Run Your First License Scan
+====================================
+
+Scan a codebase to detect licenses, copyrights, and package dependencies:
+
+.. code-block:: bash
+
+   scancode --license --copyright --info --json-pp results.json /path/to/code
+
+Review the JSON output to understand:
+
+- Detected licenses and their exact locations
+- Copyright statements and holders
+- Package metadata and dependencies
+
+
+Step 3: Generate an SBOM
+=========================
+
+Create a Software Bill of Materials for compliance documentation:
+
+.. code-block:: bash
+
+   scancode --spdx results.spdx /path/to/code
+
+Learn more about SBOM generation: :doc:`../getting-started/create-sboms`
+
+
+Step 4: Set Up License Policies
+================================
+
+Define which licenses are approved, flagged, or prohibited in your organization. Use DejaCode for enterprise policy management or create simple policy files for automated scanning.
+
+See: :doc:`../getting-started/manage-license-policies`
+
+
+***************
+Next Steps
+***************
+
+**For Ongoing Compliance**
+
+- Set up automated scanning in your CI/CD pipeline
+- Configure ScanCode.io for scheduled package scans
+- Integrate with issue tracking systems for license review workflows
+
+**Advanced Topics**
+
+- Creating custom license detection rules
+- Handling multi-license scenarios
+- Managing license obligations and attributions
+- Audit trails and compliance reporting
+
+
+**Tools to Explore**
+
+- :doc:`../aboutcode-projects/scancodeio-project` - Automated pipeline platform
+- :doc:`../aboutcode-projects/dejacode-project` - Enterprise compliance management
+- :doc:`../aboutcode-projects/scancode-workbench-project` - Visual review interface
+
+
+******************
+Common Questions
+******************
+
+**How accurate is license detection?**
+
+ScanCode provides highly accurate license detection based on full text matching. Review flagged results where confidence is low or licenses are unusual.
+
+**How do I handle false positives?**
+
+Use ScanCode Workbench to review and document your conclusions. Mark false positives and add notes for future reference and audit trails.
+
+**Can I scan container images?**
+
+Yes! ScanCode.io can scan Docker container images, extracted filesystems, and package archives. See the ScanCode.io documentation for container scanning workflows.
+
+
+******************
+Getting Help
+******************
+
+- Join the community on `Gitter <https://gitter.im/aboutcode-org/discuss>`_ or `Slack <https://join.slack.com/t/aboutcode-org/shared_invite/zt-1paqwxccw-IuafuiAvYJFkTqGaZsC1og>`_
+- Report issues on `GitHub <https://github.com/aboutcode-org/>`_
+- Check project-specific documentation for detailed guidance

--- a/docs/source/legal/index.rst
+++ b/docs/source/legal/index.rst
@@ -1,0 +1,52 @@
+.. _legal_index:
+
+#################################
+Compliance Officer Documentation
+#################################
+
+Welcome to the Compliance Officer's guide for AboutCode tools. This section helps you manage open source licenses, create Software Bill of Materials (SBOMs), ensure legal compliance, and maintain proper attribution for your organization's software. Whether you need to scan for licenses, enforce policies, or generate compliance reports, you'll find the tools and workflows you need here.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Compliance Guides
+
+   getting-started
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Quick Access
+
+   ../getting-started/start-scanning-code
+   ../getting-started/create-sboms
+   ../getting-started/manage-license-policies
+
+
+----
+
+*******************
+Key Tasks & Guides
+*******************
+
+**License Management**
+
+Use ScanCode Toolkit and ScanCode.io to identify all license obligations in your codebase. Set up automated scanning pipelines to catch license issues before they reach production.
+
+**SBOM Generation**
+
+Generate comprehensive Software Bill of Materials in industry-standard formats (SPDX, CycloneDX) for regulatory compliance, customer requirements, and internal tracking.
+
+**Policy Enforcement**
+
+Define and enforce organization-wide license policies using DejaCode. Automatically flag non-compliant components and streamline approval workflows.
+
+
+----
+
+*******************
+Related Resources
+*******************
+
+- :doc:`../aboutcode-projects/scancode-toolkit-project` - Command-line license detection
+- :doc:`../aboutcode-projects/scancodeio-project` - Automated scanning pipelines
+- :doc:`../aboutcode-projects/dejacode-project` - Enterprise compliance management
+- :doc:`../aboutcode-projects/scancode-workbench-project` - Review and document findings

--- a/docs/source/security/getting-started.rst
+++ b/docs/source/security/getting-started.rst
@@ -1,0 +1,140 @@
+.. _security_getting_started:
+
+#######################################
+Getting Started: Security Researcher
+#######################################
+
+This guide introduces you to vulnerability scanning and security analysis using AboutCode tools. Learn how to discover security issues in your software dependencies, analyze SBOMs for vulnerabilities, and implement continuous security monitoring for your applications.
+
+************
+Prerequisites
+************
+
+Before you begin, ensure you have:
+
+- Access to your application's codebase or deployment packages
+- Basic understanding of software dependencies and package managers
+- Familiarity with vulnerability concepts (CVEs, security advisories)
+- Access to deploy or run AboutCode security tools
+
+
+******************
+Quick Start Path
+******************
+
+Step 1: Install VulnerableCode
+===============================
+
+Deploy VulnerableCode to access the open vulnerability database:
+
+.. code-block:: bash
+
+   git clone https://github.com/aboutcode-org/vulnerablecode
+   cd vulnerablecode
+   # Follow installation instructions
+
+For detailed setup, see :doc:`../aboutcode-projects/vulnerablecode-project`.
+
+Alternatively, use a hosted instance if available to your organization.
+
+
+Step 2: Scan for Dependencies
+==============================
+
+Use ScanCode Toolkit to identify packages in your application:
+
+.. code-block:: bash
+
+   scancode --package --json-pp packages.json /path/to/code
+
+This detects:
+
+- Package managers and manifest files (package.json, requirements.txt, pom.xml, etc.)
+- Installed packages and their versions
+- Package URLs (PURLs) for vulnerability lookup
+
+
+Step 3: Check for Vulnerabilities
+==================================
+
+Query VulnerableCode API with package identifiers to find known vulnerabilities:
+
+.. code-block:: bash
+
+   curl "https://public.vulnerablecode.io/api/packages?purl=pkg:npm/lodash@4.17.15"
+
+Review results for:
+
+- CVE identifiers and vulnerability descriptions
+- Severity scores (CVSS ratings)
+- Affected version ranges
+- Fixed versions and patching guidance
+
+
+Step 4: Analyze SBOMs for Vulnerabilities
+==========================================
+
+If you have an existing SBOM, use ScanCode.io to automatically check all components:
+
+1. Upload your SBOM (SPDX, CycloneDX) to ScanCode.io
+2. Run the vulnerability matching pipeline
+3. Review flagged components with known security issues
+
+Learn more: :doc:`../getting-started/consume-sboms`
+
+
+***************
+Next Steps
+***************
+
+**For Continuous Security**
+
+- Integrate vulnerability scanning into CI/CD pipelines
+- Set up automated alerts for new vulnerabilities
+- Implement dependency update policies and testing
+- Track vulnerability remediation status
+
+**Advanced Security Topics**
+
+- Exploitability analysis and threat modeling
+- Security policy enforcement and risk scoring
+- Vulnerability disclosure and coordination
+- Supply chain attack detection
+
+
+**Tools to Master**
+
+- :doc:`../aboutcode-projects/vulnerablecode-project` - Comprehensive vulnerability data
+- :doc:`../aboutcode-projects/scancodeio-project` - Automated security pipelines
+- :doc:`../aboutcode-projects/purldb-project` - Package universe and metadata
+- :doc:`quickstart/first-vulnerability-scan` - Detailed scanning tutorial
+
+
+******************
+Common Questions
+******************
+
+**How current is the vulnerability data?**
+
+VulnerableCode aggregates data from multiple authoritative sources including NVD, GitHub Security Advisories, and ecosystem-specific databases. Data is regularly updated to include new disclosures.
+
+**What if my package isn't found?**
+
+Package matching uses Package URLs (PURLs) for precise identification. Ensure your package identifiers include namespace, name, and version. Check PurlDB for package metadata and alternative identifiers.
+
+**How do I prioritize vulnerabilities?**
+
+Consider multiple factors: CVSS severity score, exploit availability, component exposure (direct vs. transitive dependency), and business impact. Focus on remotely exploitable vulnerabilities in internet-facing components first.
+
+**Can I scan compiled binaries?**
+
+Scanning compiled binaries is more challenging. Container image scanning works well for layered filesystems. For native binaries, focus on dependency manifests and SBOM generation during build time.
+
+
+******************
+Getting Help
+******************
+
+- Join the community on `Gitter <https://gitter.im/aboutcode-org/discuss>`_ or `Slack <https://join.slack.com/t/aboutcode-org/shared_invite/zt-1paqwxccw-IuafuiAvYJFkTqGaZsC1og>`_
+- Report security tool issues on `GitHub <https://github.com/aboutcode-org/vulnerablecode>`_
+- For responsible vulnerability disclosure, see individual project security policies

--- a/docs/source/security/index.rst
+++ b/docs/source/security/index.rst
@@ -1,0 +1,71 @@
+.. _security_index:
+
+####################################
+Security Researcher Documentation
+####################################
+
+Welcome to the Security Researcher's guide for AboutCode tools. This section helps you discover vulnerabilities in software dependencies, analyze software composition for security risks, and secure your software supply chain. Use VulnerableCode, ScanCode.io, and PurlDB to identify, track, and remediate security vulnerabilities in your applications and infrastructure.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Security Guides
+
+   getting-started
+   quickstart/first-vulnerability-scan
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Quick Access
+
+   ../getting-started/create-sboms
+   ../getting-started/consume-sboms
+
+
+----
+
+*******************
+Key Tasks & Guides
+*******************
+
+**Vulnerability Scanning**
+
+Use VulnerableCode to identify known security vulnerabilities (CVEs, security advisories) in your software dependencies. Correlate package identifiers with comprehensive vulnerability databases for accurate risk assessment.
+
+**SBOM Analysis**
+
+Analyze Software Bill of Materials to understand your dependency tree and identify vulnerable components. Cross-reference SBOMs with VulnerableCode to prioritize remediation efforts based on actual exposure.
+
+**Supply Chain Security**
+
+Track dependencies across your software supply chain using Package URLs (PURLs) and PurlDB. Monitor for new vulnerabilities in components you depend on and receive alerts when issues are disclosed.
+
+
+----
+
+**********************
+Security Workflows
+**********************
+
+**Continuous Monitoring**
+
+Set up automated vulnerability scanning in your CI/CD pipeline using ScanCode.io. Integrate with VulnerableCode APIs to check for newly disclosed vulnerabilities in your dependencies.
+
+**Risk Assessment**
+
+Evaluate vulnerability severity, exploitability, and business impact. Use CVSS scores and exploit availability data to prioritize patching and mitigation efforts.
+
+**Remediation Tracking**
+
+Document remediation steps, track patching progress, and maintain security audit trails. Generate security reports for compliance and stakeholder communication.
+
+
+----
+
+*******************
+Related Resources
+*******************
+
+- :doc:`../aboutcode-projects/vulnerablecode-project` - Vulnerability database and API
+- :doc:`../aboutcode-projects/scancodeio-project` - Automated security scanning
+- :doc:`../aboutcode-projects/purldb-project` - Package metadata and matching
+- :doc:`../aboutcode-projects/scancode-toolkit-project` - Dependency detection

--- a/docs/source/security/quickstart/first-vulnerability-scan.rst
+++ b/docs/source/security/quickstart/first-vulnerability-scan.rst
@@ -1,0 +1,248 @@
+.. _first_vulnerability_scan:
+
+####################################
+Your First Vulnerability Scan
+####################################
+
+This quickstart guide walks you through performing your first vulnerability scan using AboutCode tools. You'll scan a sample application, identify vulnerable dependencies, and learn how to interpret and act on the results.
+
+**Time Required:** 15-30 minutes
+
+**Skill Level:** Beginner
+
+
+*************************
+What You'll Learn
+*************************
+
+- How to identify packages in an application
+- How to check packages against vulnerability databases
+- How to read and understand vulnerability reports
+- How to prioritize security findings
+- How to find remediation guidance
+
+
+*************************
+Step-by-Step Tutorial
+*************************
+
+Step 1: Choose a Sample Application
+====================================
+
+For this tutorial, you can use:
+
+- Your own application codebase
+- A sample Node.js, Python, or Java project
+- A container image from Docker Hub
+
+Example: Clone a sample vulnerable application:
+
+.. code-block:: bash
+
+   git clone https://github.com/OWASP/NodeGoat
+   cd NodeGoat
+
+
+Step 2: Install Required Tools
+===============================
+
+Install ScanCode Toolkit for package detection:
+
+.. code-block:: bash
+
+   pip install scancode-toolkit
+
+You'll also need access to VulnerableCode. For this tutorial, we'll use the public API at https://public.vulnerablecode.io
+
+
+Step 3: Detect Packages
+========================
+
+Scan the application to identify all packages:
+
+.. code-block:: bash
+
+   scancode --package --json-pp packages.json NodeGoat/
+
+**What to Look For:**
+
+Open ``packages.json`` and examine the detected packages. Each entry contains:
+
+- ``purl`` - Package URL identifier (e.g., ``pkg:npm/express@4.17.1``)
+- ``name`` and ``version`` - Package details
+- ``type`` - Package ecosystem (npm, pypi, maven, etc.)
+- ``dependencies`` - Related packages
+
+
+Step 4: Query for Vulnerabilities
+==================================
+
+For each package PURL, check VulnerableCode:
+
+.. code-block:: bash
+
+   # Example for a specific package
+   curl "https://public.vulnerablecode.io/api/packages?purl=pkg:npm/express@4.17.1" | jq
+
+Or use Python to batch check multiple packages:
+
+.. code-block:: python
+
+   import requests
+   import json
+
+   with open('packages.json', 'r') as f:
+       scan_results = json.load(f)
+
+   vulnerabilities = []
+   for file in scan_results['files']:
+       for package in file.get('packages', []):
+           purl = package.get('purl')
+           if purl:
+               response = requests.get(
+                   'https://public.vulnerablecode.io/api/packages',
+                   params={'purl': purl}
+               )
+               if response.ok:
+                   data = response.json()
+                   if data.get('results'):
+                       package_data = data['results'][0]
+                       if package_data.get('affected_by_vulnerabilities'):
+                           vulnerabilities.append({
+                               'purl': purl,
+                               'vulnerabilities': package_data['affected_by_vulnerabilities']
+                           })
+
+   print(f"Found {len(vulnerabilities)} vulnerable packages")
+
+
+Step 5: Analyze Results
+========================
+
+**Understanding Vulnerability Reports:**
+
+Each vulnerability entry includes:
+
+- **CVE ID** - Common Vulnerabilities and Exposures identifier
+- **Severity** - CVSS score (Critical: 9.0-10.0, High: 7.0-8.9, Medium: 4.0-6.9, Low: 0.1-3.9)
+- **Summary** - Description of the security issue
+- **Affected versions** - Which package versions are vulnerable
+- **Fixed versions** - Which versions contain the fix
+- **References** - Links to advisories, patches, and detailed information
+
+
+**Prioritization Criteria:**
+
+1. **Critical severity + remote exploitation** - Address immediately
+2. **High severity in direct dependencies** - High priority
+3. **Medium severity or transitive dependencies** - Schedule for remediation
+4. **Low severity** - Monitor and batch with other updates
+
+
+Step 6: Plan Remediation
+=========================
+
+For each vulnerability:
+
+**Option 1: Update to Fixed Version**
+
+.. code-block:: bash
+
+   # Example for npm
+   npm install express@latest
+
+   # Example for Python
+   pip install --upgrade requests
+
+**Option 2: Apply a Patch**
+
+Some vulnerabilities have backported patches. Check the security advisory for patch files or commits.
+
+**Option 3: Implement Workarounds**
+
+If updates aren't possible, implement mitigations like:
+
+- Disabling vulnerable features
+- Network-level restrictions
+- Input validation and sanitization
+- Web Application Firewall (WAF) rules
+
+**Option 4: Accept Risk**
+
+Document why the risk is acceptable:
+
+- Vulnerability not exploitable in your configuration
+- Component not used in production
+- Mitigation controls in place
+- Update would break critical functionality (temporary acceptance only)
+
+
+*************************
+Using ScanCode.io
+*************************
+
+For automated vulnerability scanning, use ScanCode.io:
+
+1. **Create a project** with your codebase or package archive
+2. **Run the "scan_package" pipeline** to detect packages
+3. **Run the "match_to_vulnerablecode" pipeline** to check vulnerabilities
+4. **Review results** in the web interface with filtering and export options
+
+See :doc:`../../aboutcode-projects/scancodeio-project` for installation and usage.
+
+
+*************************
+Next Steps
+*************************
+
+**Automate Scanning**
+
+- Add vulnerability checks to CI/CD pipelines
+- Schedule regular scans of deployed applications
+- Set up alerts for new vulnerabilities in used packages
+
+**Deep Dive**
+
+- :doc:`../getting-started` - Comprehensive security workflows
+- :doc:`../../aboutcode-projects/vulnerablecode-project` - VulnerableCode API documentation
+- :doc:`../../aboutcode-projects/scancodeio-project` - Automated pipeline setup
+
+**Best Practices**
+
+- Maintain an accurate SBOM of all applications
+- Keep dependencies up to date with security patches
+- Monitor security advisories for packages you use
+- Test updates in non-production environments first
+- Document remediation decisions and risk acceptances
+
+
+*************************
+Troubleshooting
+*************************
+
+**Package not found in VulnerableCode**
+
+- Verify the PURL format is correct
+- Check if the package exists in PurlDB
+- Some packages may not have vulnerability data available
+
+**Too many vulnerabilities detected**
+
+- Start with Critical and High severity issues
+- Focus on direct dependencies before transitive ones
+- Group similar issues for batch remediation
+
+**False positives**
+
+- Verify the vulnerable code path is actually used
+- Check if your configuration disables vulnerable features
+- Document false positives for future reference
+
+
+*************************
+Getting Help
+*************************
+
+- Community chat: `Gitter <https://gitter.im/aboutcode-org/discuss>`_ or `Slack <https://join.slack.com/t/aboutcode-org/shared_invite/zt-1paqwxccw-IuafuiAvYJFkTqGaZsC1og>`_
+- Report issues: `VulnerableCode GitHub <https://github.com/aboutcode-org/vulnerablecode/issues>`_
+- Security questions: Reach out on community channels for guidance

--- a/docs/user-journey-compliance-officer.md
+++ b/docs/user-journey-compliance-officer.md
@@ -1,0 +1,765 @@
+# User Journey: First-Time Compliance Officer
+
+## Persona Profile
+
+**Name:** Sarah Chen  
+**Role:** Open Source Compliance Officer  
+**Background:** Legal background, familiar with license compliance concepts, new to automated scanning tools  
+**Organization:** Mid-sized software company building a web application  
+**Experience Level:** Beginner with software composition analysis tools
+
+---
+
+## 1. Goal
+
+**Primary Objective:** Create a complete software bill of materials (SBOM) for a product that identifies all third-party components, their licenses, and any potential license compliance issues.
+
+**Success Criteria:**
+- Identify all open source components used in the product
+- Document the license for each component
+- Flag any license conflicts or policy violations
+- Generate attribution documents for legal distribution
+- Produce an SBOM in industry-standard format (SPDX or CycloneDX)
+
+**Business Driver:** The company needs to deliver an SBOM to a major customer as part of a contract requirement, and the legal team must ensure no GPL-licensed code is included in the proprietary product.
+
+---
+
+## 2. Entry Point
+
+**Discovery Path:**  
+Sarah arrives at the AboutCode documentation homepage after searching for "open source license compliance tools." She sees the persona-based landing page with three options.
+
+**First Click:**  
+She clicks the "👔 Compliance Officer" card, which takes her to:  
+→ **`legal/getting-started.html`**
+
+**Initial Questions:**
+- "What information can I get from these tools?"
+- "Do I need to install software or can I use a web interface?"
+- "How long will this take?"
+- "What do I need to prepare before starting?"
+
+**Recommended Entry Documentation:**
+1. Start at: `legal/getting-started.html` (Compliance Getting Started)
+2. Review: `getting-started/start-scanning-code.html` (Overview of scanning)
+3. Understand: `aboutcode-projects/scancodeio-project.html` (Primary tool overview)
+
+---
+
+## 3. Step-by-Step Workflow
+
+### Phase 1: Preparation (Day 1, Morning)
+
+#### Step 1.1: Understand the Tool Landscape
+**Action:** Read about which AboutCode tools are relevant for compliance work
+
+**Tools to Learn:**
+- **ScanCode.io** - Web-based platform for scanning packages and generating reports
+- **DejaCode** - Product inventory management and policy enforcement (optional for first scan)
+- **ScanCode Toolkit** - Command-line scanner (alternative if comfortable with terminal)
+
+**Documentation Pages:**
+- Read: `aboutcode-project-overview.html`
+- Review: `aboutcode-projects/scancodeio-project.html`
+- Bookmark: `legal/reference/license-categories-explained.html` (for later reference)
+
+**Decision Point:** Sarah chooses ScanCode.io because it has a web interface and doesn't require command-line expertise.
+
+---
+
+#### Step 1.2: Install or Access ScanCode.io
+**Action:** Set up access to ScanCode.io platform
+
+**Options:**
+- Install locally using Docker (IT department can help)
+- Request access to company's existing instance (if available)
+- Use a trial/evaluation instance for testing
+
+**Documentation Pages:**
+- Follow: `aboutcode-projects/scancodeio-project.html` → Installation link
+- Reference: ScanCode.io ReadTheDocs installation guide
+
+**What Sarah Does:** Works with IT to get a Docker instance running on her laptop for initial testing.
+
+**Time Estimate:** 1-2 hours (with IT support)
+
+---
+
+#### Step 1.3: Gather Product Information
+**Action:** Collect the software package or codebase to analyze
+
+**What Sarah Needs:**
+- The product source code repository location
+- Any container images or build artifacts
+- List of declared dependencies (package.json, requirements.txt, pom.xml, etc.)
+- Access credentials to download the codebase
+
+**Documentation Pages:**
+- Review: `getting-started/start-scanning-code.html` (understand what can be scanned)
+
+**Sarah's Preparation:**
+- Downloads a ZIP of the latest release branch
+- Gets the Docker container image from the build system
+- Collects dependency manifest files
+
+**Time Estimate:** 30 minutes
+
+---
+
+### Phase 2: First Scan (Day 1, Afternoon)
+
+#### Step 2.1: Create Your First Project in ScanCode.io
+**Action:** Upload codebase and initiate a scan
+
+**Process:**
+1. Open ScanCode.io web interface
+2. Click "Create New Project"
+3. Provide a project name: "MyProduct-v2.5-Compliance-Audit"
+4. Upload the product ZIP file or provide repository URL
+5. Select the pipeline: **"scan_codebase"** (for source code analysis)
+
+**Documentation Pages:**
+- Follow: `getting-started/start-scanning-code.html#scan-software-using-scancodeio`
+- Reference: ScanCode.io tutorial for creating projects
+
+**What Happens:** ScanCode.io processes the upload, extracts files, and begins scanning for:
+- Licenses in source files
+- Copyright statements
+- Package manifests and dependencies
+
+**Time Estimate:** 5 minutes to set up, 15-45 minutes for scan to complete (depending on codebase size)
+
+---
+
+#### Step 2.2: Review Initial Scan Results
+**Action:** Understand what was found in the initial scan
+
+**How to Navigate Results:**
+1. Open the completed project in ScanCode.io
+2. Review the "Packages" tab - shows detected third-party components
+3. Check the "Resources" tab - shows individual files and their detected licenses
+4. Look at the "Summary" section - provides overview statistics
+
+**What Sarah Sees:**
+- 247 packages detected
+- 15 different licenses found
+- 3 packages flagged with "AGPL-3.0" (potential policy issue!)
+- Some files showing "Unknown" or "No license detected"
+
+**Documentation Pages:**
+- Review: `getting-started/start-scanning-code.html#review-scan-results`
+- Reference: `legal/reference/license-categories-explained.html` (to understand license types)
+
+**Time Estimate:** 30 minutes to explore
+
+---
+
+### Phase 3: Analysis and Investigation (Day 2)
+
+#### Step 3.1: Investigate License Policy Violations
+**Action:** Examine the AGPL-licensed components that violate company policy
+
+**Investigation Process:**
+1. Click on each AGPL package to see details
+2. Check if these are direct dependencies or transitive (dependencies of dependencies)
+3. Determine if they're actually included in the distributed product
+4. Look for alternative packages with more permissive licenses
+
+**Questions Sarah Asks:**
+- "Is this package really needed in production, or is it a development tool?"
+- "Are we linking to this library or just using it during the build?"
+- "Can we replace this with an Apache or MIT-licensed alternative?"
+
+**Documentation Pages:**
+- Reference: `legal/guides/handle-license-conflicts.html` (hypothetical - needs to be created)
+- Learn: `legal/reference/common-license-scenarios.html` (hypothetical - for GPL scenarios)
+
+**Sarah's Finding:** Two AGPL packages are development-only test dependencies that aren't shipped. One is a transitive dependency that needs engineering review.
+
+**Time Estimate:** 2-3 hours
+
+---
+
+#### Step 3.2: Handle Unclear or Missing License Information
+**Action:** Resolve packages showing "Unknown" or ambiguous licenses
+
+**Common Scenarios:**
+- Package has license file but wasn't detected
+- Package has multiple licenses (dual licensing)
+- Package has license in README but not in standard location
+- License detection confidence is below threshold
+
+**Resolution Steps:**
+1. Manually review the package source code
+2. Check the package's upstream repository or package registry
+3. Document findings in notes
+4. May need to contact package maintainers
+5. Update scan results with manual assertions (in DejaCode, if using it)
+
+**Documentation Pages:**
+- Reference: `legal/guides/understand-license-obligations.html` (hypothetical)
+- Review: License detection confidence scores in scan results
+
+**Sarah's Action:** Reviews 12 unclear packages, documents findings in a spreadsheet for now, plans to use DejaCode for formal tracking later.
+
+**Time Estimate:** 1-2 hours
+
+---
+
+### Phase 4: Policy Configuration (Day 3)
+
+#### Step 4.1: Set Up License Policies (Optional but Recommended)
+**Action:** Configure which licenses are approved, restricted, or prohibited
+
+**Tool Choice:** DejaCode for enterprise policy management
+
+**Policy Categories Set Up:**
+- **Approved:** MIT, Apache-2.0, BSD-3-Clause, BSD-2-Clause
+- **Restricted (Review Required):** LGPL-2.1, LGPL-3.0, MPL-2.0
+- **Prohibited:** GPL-2.0, GPL-3.0, AGPL-3.0 (for proprietary distribution)
+
+**Documentation Pages:**
+- Follow: `getting-started/manage-license-policies.html`
+- Setup: DejaCode ReadTheDocs for policy configuration
+- Export: Policy file for use in future scans
+
+**Benefits:**
+- Future scans automatically flag policy violations
+- Consistent policy enforcement across teams
+- Audit trail of decisions
+
+**Time Estimate:** 1-2 hours
+
+---
+
+#### Step 4.2: Configure Integration Between Tools
+**Action:** Connect ScanCode.io with DejaCode for enhanced workflow
+
+**Integration Benefits:**
+- Import scan results directly into DejaCode products
+- Track components across multiple product versions
+- Generate attribution documents automatically
+- Maintain historical compliance records
+
+**Documentation Pages:**
+- Follow: `getting-started/create-sboms.html#import-scan-results-to-dejacode`
+- Configure: DejaCode integration settings
+
+**Sarah's Setup:** Links her ScanCode.io instance to DejaCode, creates a "Product" for her application.
+
+**Time Estimate:** 30 minutes
+
+---
+
+### Phase 5: Deliverables Generation (Day 3-4)
+
+#### Step 5.1: Generate the SBOM
+**Action:** Export scan results as standards-compliant SBOM
+
+**SBOM Format Options:**
+- **SPDX** (Software Package Data Exchange) - ISO standard, legal focus
+- **CycloneDX** - OWASP standard, security focus, includes vulnerability data
+
+**Export Process in ScanCode.io:**
+1. Open the completed project
+2. Navigate to "Output Files" section
+3. Download SPDX or CycloneDX file
+4. Validate the SBOM contains all required components
+
+**Documentation Pages:**
+- Reference: `getting-started/create-sboms.html`
+- Learn: SBOM format differences and when to use each
+
+**What Sarah Gets:**
+- `myproduct-v2.5-sbom.spdx.json` - Complete component inventory
+- Machine-readable format for customer systems
+- Human-readable HTML report for internal review
+
+**Time Estimate:** 15 minutes
+
+---
+
+#### Step 5.2: Create Attribution Documents
+**Action:** Generate legal notices and attribution text for distribution
+
+**Required Outputs:**
+- NOTICE file with all copyright notices
+- LICENSE file with full license texts
+- Attribution report for documentation
+
+**Tools Used:**
+- **DejaCode** - Primary attribution generation
+- **AboutCode Toolkit** - Alternative command-line option
+
+**Documentation Pages:**
+- Follow: `getting-started/create-sboms.html#generate-attribution-and-sboms`
+- Reference: `aboutcode-projects/aboutcode-toolkit-project.html` (alternative method)
+
+**What Sarah Creates:**
+- NOTICE.txt - All copyright statements (12 pages)
+- LICENSES/ directory - Full license texts for all detected licenses
+- Attribution.html - Formatted attribution report for product documentation
+
+**Time Estimate:** 30 minutes
+
+---
+
+#### Step 5.3: Create Executive Summary Report
+**Action:** Prepare findings summary for legal and engineering teams
+
+**Report Contents:**
+1. **Overview:** 247 components analyzed, 15 unique licenses
+2. **Policy Compliance:** 3 violations found, 2 resolved, 1 requires engineering action
+3. **Risk Assessment:** Low risk - no copyleft licenses in distributed code
+4. **Action Items:** 
+   - Replace one AGPL library with alternative
+   - Document 5 components with unclear licenses
+   - Set up automated scanning for future releases
+5. **Deliverables:** SBOM file and attribution documents attached
+
+**Documentation Pages:**
+- Template: `legal/guides/create-compliance-artifacts.html` (hypothetical)
+
+**Time Estimate:** 1 hour
+
+---
+
+## 4. Expected Outputs
+
+### Primary Deliverables
+
+#### 4.1 Software Bill of Materials (SBOM)
+**File:** `myproduct-v2.5-sbom.spdx.json`
+
+**Contents:**
+- Complete list of 247 components
+- Package name, version, and Package URL (PURL) for each
+- Declared license for each component
+- License expressions for multi-licensed components
+- Supplier information where available
+- File hashes for verification
+
+**Use Cases:**
+- Submit to customer as contractual requirement
+- Share with security team for vulnerability scanning
+- Archive for compliance records
+- Use as baseline for next release comparison
+
+---
+
+#### 4.2 Attribution Documentation
+**Files:** 
+- `NOTICE.txt` - Copyright notices
+- `LICENSES/` directory - Full license texts
+- `Attribution.html` - Formatted report
+
+**Contents:**
+- Copyright statements from all components
+- Full text of all applicable licenses
+- Attribution requirements per license
+- Source code availability information (if required)
+
+**Use Cases:**
+- Include in product distribution (NOTICE file)
+- Add to product documentation (Attribution report)
+- Provide to customers upon request
+- Satisfy license requirements
+
+---
+
+#### 4.3 Compliance Analysis Report
+**File:** `Compliance-Analysis-MyProduct-v2.5.pdf`
+
+**Sections:**
+1. Executive Summary
+2. Methodology (tools used, scope of analysis)
+3. Findings
+   - Components by license type
+   - Policy violations and resolutions
+   - Unknown or unclear licenses
+4. Risk Assessment
+5. Recommendations
+6. Appendices (detailed component lists)
+
+**Audience:** Legal counsel, engineering leadership, customers
+
+---
+
+#### 4.4 Component Tracking Database
+**System:** DejaCode Product Inventory
+
+**Contents:**
+- All 247 components tracked as "Product Components"
+- License conclusions documented
+- Usage policies assigned
+- Review status for each component
+- Historical tracking across versions
+
+**Benefits:**
+- Searchable inventory for future questions
+- Track component updates and new versions
+- Audit trail for compliance decisions
+- Reusable for next release (update scan vs. full rescan)
+
+---
+
+### Secondary Outputs
+
+#### 4.5 Policy Configuration Files
+**Files:**
+- `license-policies.yml` - Exportable policy definitions
+- Used for automated scanning in CI/CD pipeline
+
+#### 4.6 Action Items List
+**Tracking:**
+- 1 component to replace (AGPL dependency)
+- 5 components needing manual license clarification
+- Engineering tasks assigned with priorities
+
+---
+
+## 5. Common Pitfalls
+
+### Pitfall 1: Incomplete Codebase Scanning
+**Problem:** Only scanning the source code repository, missing compiled dependencies
+
+**What Gets Missed:**
+- Binary dependencies from package managers (npm, Maven, pip)
+- Third-party libraries bundled in build artifacts
+- Container base images and their components
+- Vendored dependencies in third-party directories
+
+**Solution:**
+- Scan both source code AND build artifacts
+- Use appropriate pipelines: "scan_codebase" + "scan_package" or "docker_image"
+- Review package manifests to ensure all dependencies were detected
+- Compare scan results with declared dependencies
+
+**Documentation:** Review pipeline options in ScanCode.io tutorials
+
+---
+
+### Pitfall 2: Trusting Declared Licenses Without Verification
+**Problem:** Assuming package metadata is accurate without checking actual files
+
+**Risk:**
+- Package.json says "MIT" but actual code has "GPL" headers
+- License changed between versions but metadata not updated
+- Dual-licensed projects where metadata shows only one option
+
+**Solution:**
+- Review file-level scan results, not just package-level
+- Check confidence scores on license detections
+- Manually verify critical or high-risk components
+- Document discrepancies between declared and detected licenses
+
+**Documentation:** `legal/guides/understand-license-obligations.html`
+
+---
+
+### Pitfall 3: Ignoring Transitive Dependencies
+**Problem:** Only reviewing direct dependencies, missing "dependencies of dependencies"
+
+**Example:**
+- You use Package A (MIT licensed)
+- Package A depends on Package B (GPL licensed)
+- Your product now has GPL code even though you didn't explicitly include it
+
+**Solution:**
+- Ensure full dependency tree scanning is enabled
+- Review the dependency graph in scan results
+- Understand which dependencies are runtime vs. build-time
+- Use policy enforcement to catch transitive violations
+
+**Documentation:** Review dependency analysis features
+
+---
+
+### Pitfall 4: Confusion About License Obligations
+**Problem:** Not understanding what different licenses actually require
+
+**Common Misunderstandings:**
+- "MIT license means no attribution needed" (FALSE - attribution required)
+- "Using LGPL is the same as GPL" (FALSE - different linking rules)
+- "Internal use has no license requirements" (PARTIAL - some licenses have internal restrictions)
+
+**Solution:**
+- Read: `legal/reference/license-categories-explained.html`
+- Consult: `legal/reference/common-license-scenarios.html`
+- When in doubt: Seek legal counsel for license interpretation
+- Document your interpretations and decisions
+
+**Key Learning:** Licenses have different requirements for attribution, source disclosure, and distribution.
+
+---
+
+### Pitfall 5: One-Time Compliance Check
+**Problem:** Treating compliance as a single audit instead of ongoing process
+
+**Reality:**
+- Dependencies get updated regularly
+- New vulnerabilities are discovered
+- Code changes between releases
+- License policies may evolve
+
+**Solution:**
+- Set up automated scanning in CI/CD pipeline
+- Re-scan before each release
+- Track component changes between versions
+- Monitor for license changes in updated dependencies
+- Subscribe to security bulletins for your components
+
+**Documentation:** `developer/guides/ci-cd-integration-patterns.html`
+
+---
+
+### Pitfall 6: Poor Documentation of Decisions
+**Problem:** Not recording why certain license decisions were made
+
+**Impact:**
+- Can't explain decisions in future audits
+- Different team members make inconsistent decisions
+- Lost knowledge when team members leave
+- Difficult to respond to customer questions
+
+**Solution:**
+- Use DejaCode to document license conclusions and rationale
+- Maintain a decisions log or wiki
+- Tag components with review status and notes
+- Create templates for common decision scenarios
+
+---
+
+## 6. Next Steps
+
+### Immediate Actions (This Week)
+
+#### 6.1 Share Results with Stakeholders
+**Action Items:**
+- Present compliance report to legal counsel for review
+- Share AGPL finding with engineering team for remediation
+- Deliver SBOM to customer (if deadline driven)
+- Schedule follow-up meeting to discuss ongoing process
+
+**Preparation:** Create a presentation summarizing findings and recommendations
+
+---
+
+#### 6.2 Address Policy Violations
+**Action Items:**
+- Work with engineering to replace AGPL dependency
+- Get legal sign-off on any waiver decisions
+- Document risk acceptance for any remaining issues
+- Set deadline for remediation
+
+**Timeline:** Target resolution within 2 weeks
+
+---
+
+#### 6.3 Complete Documentation
+**Action Items:**
+- Finalize manual license determinations
+- Archive all compliance artifacts in shared repository
+- Update product documentation with attribution information
+- Create compliance folder for this product version
+
+---
+
+### Short-Term Goals (This Month)
+
+#### 6.4 Implement DejaCode Product Tracking
+**Why:** Move from ad-hoc spreadsheets to formal tracking system
+
+**Benefits:**
+- Track components across multiple products
+- Maintain history of license decisions
+- Reuse component analysis for other products
+- Generate reports more easily
+
+**Documentation:** `getting-started/create-sboms.html#import-scan-results-to-dejacode`
+
+**Time Investment:** 4-8 hours for initial setup and data import
+
+---
+
+#### 6.5 Create Compliance Process Documentation
+**Deliverable:** Internal wiki or document describing the compliance workflow
+
+**Contents:**
+- When to perform compliance scans (before each release)
+- Who is responsible for each step
+- How to use ScanCode.io and DejaCode
+- Escalation process for issues
+- Templates for compliance reports
+
+**Audience:** Future compliance team members, engineering managers, legal counsel
+
+---
+
+#### 6.6 Train Engineering Team
+**Goal:** Help developers understand compliance requirements
+
+**Topics:**
+- How to check licenses before adding dependencies
+- Understanding the license policy
+- How to interpret scan results
+- When to escalate to compliance team
+
+**Format:** 1-hour workshop or recorded training video
+
+---
+
+### Long-Term Strategy (Next Quarter)
+
+#### 6.7 Automate Compliance Scanning in CI/CD
+**Goal:** Catch compliance issues early in development
+
+**Implementation:**
+- Set up ScanCode.io API integration in CI/CD pipeline
+- Configure automated scans on every pull request or release branch
+- Set policy thresholds (block builds with prohibited licenses)
+- Send alerts to compliance team for review items
+
+**Documentation:** 
+- `developer/guides/ci-cd-integration-patterns.html`
+- `aboutcode-projects/scancode-action-project.html` (for GitHub Actions)
+
+**Benefits:**
+- Prevent prohibited licenses from merging
+- Reduce compliance review time
+- Create audit trail automatically
+- Shift compliance left in development
+
+---
+
+#### 6.8 Expand to Vulnerability Scanning
+**Goal:** Add security analysis alongside license compliance
+
+**Tools to Integrate:**
+- **VulnerableCode** - Open source vulnerability database
+- **ScanCode.io** - Already scans for vulnerabilities if configured
+
+**Process:**
+- Enable vulnerability scanning in ScanCode.io pipelines
+- Generate VEX (Vulnerability Exploitability eXchange) documents
+- Track CVEs alongside license information in SBOMs
+- Coordinate with security team on remediation
+
+**Documentation:**
+- `security/getting-started.html`
+- `security/guides/triage-vulnerabilities.html` (hypothetical)
+
+---
+
+#### 6.9 Establish Metrics and KPIs
+**Goal:** Measure and improve compliance program effectiveness
+
+**Metrics to Track:**
+- Time from scan to SBOM delivery
+- Number of policy violations per release
+- Percentage of components with clear license information
+- Time to resolve compliance issues
+- Number of manual interventions required
+
+**Review Frequency:** Monthly or per-release
+
+---
+
+#### 6.10 Build a Component Repository
+**Goal:** Create pre-approved component catalog
+
+**Benefits:**
+- Developers can choose from pre-vetted components
+- Reduce duplicate license reviews
+- Faster approval for common packages
+- Consistent component usage across products
+
+**Implementation:**
+- Use DejaCode to maintain approved component list
+- Document license obligations for each
+- Publish catalog to engineering team
+- Update quarterly
+
+---
+
+### Continuous Improvement
+
+#### 6.11 Stay Current with AboutCode Updates
+**Activities:**
+- Subscribe to AboutCode project announcements
+- Join community Gitter/Slack channels
+- Review release notes for new features
+- Attend AboutCode webinars or conferences
+
+**Community Resources:**
+- Gitter: https://gitter.im/aboutcode-org/discuss
+- GitHub: https://github.com/aboutcode-org/
+
+---
+
+#### 6.12 Contribute Back to Community
+**Opportunities:**
+- Report bugs or unclear documentation
+- Suggest new license detection rules
+- Share compliance workflow patterns
+- Contribute to license database improvements
+
+**Impact:** Improve tools for entire community while strengthening your implementation
+
+---
+
+## Journey Complete!
+
+Congratulations! Sarah has successfully:
+
+✅ Completed her first compliance scan  
+✅ Generated an SBOM and attribution documents  
+✅ Identified and addressed license policy issues  
+✅ Established a repeatable compliance process  
+✅ Created a foundation for automated compliance
+
+**From first scan to mature compliance program:** Sarah's journey transforms from a one-time audit to an integrated, automated compliance operation that protects her organization while enabling efficient software development.
+
+**Time Investment Summary:**
+- Initial scan and analysis: 3-4 days
+- Process setup and documentation: 1 week
+- Automation and integration: 2-4 weeks
+- Mature program operation: Ongoing, but streamlined
+
+**Return on Investment:**
+- Faster time to delivery for customer SBOMs
+- Reduced legal risk from license violations
+- Improved security posture
+- Auditable compliance trail
+- Competitive advantage in enterprise sales
+
+---
+
+## Additional Resources
+
+### Documentation Pages Referenced
+- `legal/getting-started.html` - Compliance officer entry point
+- `getting-started/start-scanning-code.html` - Scanning basics
+- `getting-started/create-sboms.html` - SBOM generation workflow
+- `getting-started/manage-license-policies.html` - Policy configuration
+- `aboutcode-project-overview.html` - All AboutCode projects
+- `aboutcode-projects/scancodeio-project.html` - ScanCode.io details
+- `aboutcode-projects/dejacode-project.html` - DejaCode details
+
+### External Resources
+- ScanCode.io ReadTheDocs (installation and tutorials)
+- DejaCode ReadTheDocs (product management)
+- SPDX Specification
+- CycloneDX Specification
+- Open Source License texts and interpretations
+
+### Support Channels
+- Gitter: https://gitter.im/aboutcode-org/discuss
+- Slack: AboutCode community workspace
+- GitHub Issues: Project-specific repositories
+- Email: Project mailing lists
+
+---
+
+*This user journey is designed to be updated as AboutCode tools evolve and new features are added. Last updated: February 2026*

--- a/docs/user-journey-devops-engineer.md
+++ b/docs/user-journey-devops-engineer.md
@@ -419,7 +419,8 @@ class ScanCodeIOClient:
     
     def upload_file(self, project_uuid: str, file_path: str) -> Dict:
         """Upload a file to project"""
-        files = {'upload_file': open(file_path, 'rb')}
+        with open(file_path, 'rb') as f:
+            files = {'upload_file': f}
         headers = {'Authorization': self.headers['Authorization']}
         
         response = requests.post(
@@ -549,7 +550,7 @@ def scan_repository(repo_path: str, project_name: str) -> int:
     
     # Load license policy
     policy_url = os.getenv('LICENSE_POLICY_URL')
-    policy = requests.get(policy_url).json() if policy_url else {}
+    policy = yaml.safe_load(requests.get(policy_url).text) if policy_url else {}
     
     # Initialize client
     client = ScanCodeIOClient(scancodeio_url, scancodeio_key)

--- a/docs/user-journey-devops-engineer.md
+++ b/docs/user-journey-devops-engineer.md
@@ -1,0 +1,1537 @@
+# User Journey: Senior DevOps Engineer - CI/CD Integration
+
+## Persona Profile
+
+**Name:** Alex Rivera  
+**Role:** Senior DevOps Engineer / Platform Team Lead  
+**Background:** 8+ years in DevOps, expert in CI/CD automation, container orchestration, IaC  
+**Organization:** SaaS company, microservices architecture, 50+ repositories  
+**Tech Stack:** GitHub, GitHub Actions, Docker, Kubernetes, Python, Node.js, Go  
+**Experience Level:** Advanced with automation, new to software composition analysis tools
+
+---
+
+## 1. Goal
+
+**Primary Objective:** Implement automated license compliance and vulnerability scanning in CI/CD pipelines across all production repositories, with automated policy enforcement and security team notifications.
+
+**Technical Requirements:**
+- Scan every pull request for license violations and high-severity CVEs
+- Block merges if prohibited licenses (GPL, AGPL) are detected
+- Generate SBOMs automatically for every release build
+- Alert security team on CVSS 9.0+ vulnerabilities
+- Export scan results to centralized security dashboard
+- Support multiple languages/ecosystems: npm, pip, Maven, Go modules
+- Keep scan time under 5 minutes for typical PR builds
+
+**Success Metrics:**
+- 100% PR scan coverage across production repos
+- <1% false positive rate on license policy violations
+- Zero prohibited licenses merged to production
+- SBOM available within 2 minutes of release tag
+- 95% of critical vulnerabilities triaged within 24 hours
+
+**Business Drivers:**
+- SOC 2 compliance requirement for SBOM generation
+- Customer contracts requiring CVE disclosure
+- Reduce legal risk from open source licensing
+- Improve supply chain security posture
+
+---
+
+## 2. Prerequisites
+
+### 2.1 Infrastructure Setup
+
+#### ScanCode.io Server Deployment
+**Recommended:** Self-hosted instance for API access and data retention
+
+```bash
+# Deploy ScanCode.io via Docker Compose
+git clone https://github.com/aboutcode-org/scancode.io.git
+cd scancode.io
+
+# Create environment configuration
+cat > .env << EOF
+SCANCODEIO_DB_PASSWORD=$(openssl rand -base64 32)
+SCANCODEIO_SECRET_KEY=$(openssl rand -base64 50)
+SCANCODEIO_ALLOWED_HOSTS=scancode.internal.company.com
+SCANCODEIO_REQUIRE_AUTHENTICATION=True
+SCANCODEIO_WORKSPACE_LOCATION=/var/scancodeio/workspace
+EOF
+
+# Start services
+docker-compose up -d
+
+# Create admin user
+docker-compose exec web scancodeio createsuperuser
+
+# Create API token for CI/CD
+docker-compose exec web scancodeio create-user cicd-bot --api-key
+```
+
+**Infrastructure Requirements:**
+- 4 CPU / 8GB RAM minimum (16GB recommended for parallel scans)
+- 100GB storage for workspace and database
+- PostgreSQL 12+ and Redis 6+
+- Network access from CI/CD runners
+- HTTPS with valid certificate (Let's Encrypt recommended)
+
+---
+
+#### VulnerableCode Deployment (Optional but Recommended)
+**Purpose:** Enhanced vulnerability correlation and tracking
+
+```bash
+# Deploy VulnerableCode
+git clone https://github.com/aboutcode-org/vulnerablecode.git
+cd vulnerablecode
+
+# Configure environment
+cat > .env << EOF
+VULNERABLECODE_DB_PASSWORD=$(openssl rand -base64 32)
+VULNERABLECODE_SECRET_KEY=$(openssl rand -base64 50)
+VCIO_HOST=scancode.internal.company.com
+ENABLE_LIVE_EVAL=true
+EOF
+
+# Start and initialize
+docker-compose up -d
+docker-compose exec vulnerablecode python manage.py migrate
+docker-compose exec vulnerablecode python manage.py import --importer github
+```
+
+**Integration:** Link VulnerableCode to ScanCode.io for enhanced vulnerability data
+
+---
+
+### 2.2 Local Development Tools
+
+#### ScanCode Toolkit Installation
+**Use Case:** Local testing and CLI automation
+
+```bash
+# Install via pip (requires Python 3.8+)
+python -m venv venv-scancode
+source venv-scancode/bin/activate  # Windows: .\venv-scancode\Scripts\activate
+pip install scancode-toolkit[full]
+
+# Verify installation
+scancode --version
+# Expected: ScanCode Toolkit version 32.x.x
+
+# Configure for optimal performance
+export SCANCODE_PROCESSES=4  # Parallel processes
+export SCANCODE_TEMP=/tmp    # Temp directory
+```
+
+---
+
+#### Install AboutCode CLI Tools
+
+```bash
+# Install scancode.io CLI client
+pip install scancodeio-client
+
+# Install Python inspection tools
+pip install python-inspector
+
+# Install SBOM validation tools
+pip install cyclonedx-bom spdx-tools
+```
+
+---
+
+### 2.3 GitHub Configuration
+
+#### Repository Secrets Setup
+
+```bash
+# Add to GitHub repository or organization secrets
+SCANCODEIO_URL=https://scancode.internal.company.com
+SCANCODEIO_API_KEY=<token-from-deployment>
+VULNERABLECODE_URL=https://vulnerablecode.internal.company.com
+SLACK_WEBHOOK_SECURITY=<security-team-webhook>
+LICENSE_POLICY_URL=https://raw.githubusercontent.com/company/policies/main/license-policy.yml
+```
+
+#### License Policy Configuration
+
+**File:** `license-policy.yml` (stored in policy repo)
+
+```yaml
+# License policy for automated enforcement
+license_policies:
+  approved:
+    - MIT
+    - Apache-2.0
+    - BSD-2-Clause
+    - BSD-3-Clause
+    - ISC
+    - CC0-1.0
+  
+  restricted:  # Require manual review
+    - LGPL-2.1
+    - LGPL-3.0
+    - MPL-2.0
+    - EPL-1.0
+    - EPL-2.0
+  
+  prohibited:  # Block PR merge
+    - GPL-2.0
+    - GPL-3.0
+    - AGPL-3.0
+    - SSPL-1.0
+    - Commons-Clause
+
+compliance:
+  fail_on_prohibited: true
+  fail_on_high_severity: true  # CVSS >= 9.0
+  require_sbom_on_release: true
+  
+vulnerability_thresholds:
+  critical: 0    # Block on any CVSS 9.0+
+  high: 5        # Block if >5 CVSS 7.0-8.9
+  medium: 20     # Warn if >20 CVSS 4.0-6.9
+```
+
+---
+
+## 3. CLI Commands for Scanning
+
+### 3.1 Basic License Scanning
+
+#### Scan Codebase for Licenses and Copyrights
+
+```bash
+# Full scan with all detections
+scancode \
+  --license \
+  --copyright \
+  --package \
+  --info \
+  --classify \
+  --summary \
+  --json-pp scan-results.json \
+  --html scan-results.html \
+  /path/to/codebase
+
+# Focused license-only scan (faster)
+scancode \
+  --license \
+  --license-score 80 \
+  --json-pp licenses.json \
+  --processes 4 \
+  /path/to/codebase
+```
+
+**Key Options:**
+- `--license-score 80`: Only report matches with 80%+ confidence
+- `--processes 4`: Parallel scanning (adjust to CPU cores)
+- `--json-pp`: Pretty-printed JSON output
+- `--classify`: Classify files by type
+
+---
+
+#### Package Manifest Analysis
+
+```bash
+# Detect and resolve dependencies from package managers
+scancode \
+  --package \
+  --json-pp packages.json \
+  /path/to/project
+
+# Output includes:
+# - package.json (npm), requirements.txt (pip), pom.xml (Maven), go.mod, etc.
+# - Detected package names, versions, PURLs
+# - Declared licenses from package metadata
+```
+
+---
+
+### 3.2 Vulnerability Scanning
+
+#### Using ScanCode with Vulnerability Detection
+
+```bash
+# Requires vulnerablecode integration
+scancode \
+  --package \
+  --vulnerabilities \
+  --json-pp vulns.json \
+  /path/to/project
+
+# Filter to show only critical vulnerabilities
+jq '.packages[] | select(.vulnerabilities != null) | 
+    {name: .name, version: .version, vulns: .vulnerabilities}' vulns.json
+```
+
+---
+
+### 3.3 SBOM Generation
+
+#### Generate SPDX SBOM
+
+```bash
+# Scan and generate SPDX 2.3 SBOM
+scancode \
+  --license \
+  --copyright \
+  --package \
+  --spdx-tv sbom.spdx \
+  /path/to/codebase
+
+# Or JSON format
+scancode \
+  --license \
+  --copyright \
+  --package \
+  --spdx-rdf sbom.spdx.json \
+  /path/to/codebase
+```
+
+#### Generate CycloneDX SBOM
+
+```bash
+# Scan and generate CycloneDX 1.4
+scancode \
+  --license \
+  --copyright \
+  --package \
+  --cyclonedx sbom.cdx.json \
+  /path/to/codebase
+
+# Validate the generated SBOM
+cyclonedx-py validate --input-file sbom.cdx.json
+```
+
+---
+
+### 3.4 Policy Enforcement
+
+#### Apply License Policy Check
+
+```bash
+# Download policy file
+curl -o license-policy.yml "$LICENSE_POLICY_URL"
+
+# Scan with policy enforcement
+scancode \
+  --license \
+  --license-policy license-policy.yml \
+  --json-pp results-with-policy.json \
+  /path/to/codebase
+
+# Check for policy violations
+violations=$(jq '[.files[] | select(.license_policy_violations) | 
+               .license_policy_violations[]] | length' results-with-policy.json)
+
+if [ "$violations" -gt 0 ]; then
+  echo "❌ Found $violations license policy violations"
+  jq '.files[] | select(.license_policy_violations) | 
+      {path: .path, violations: .license_policy_violations}' \
+      results-with-policy.json
+  exit 1
+fi
+
+echo "✅ No license policy violations"
+```
+
+---
+
+### 3.5 Differential Scanning
+
+#### Compare Against Base Branch
+
+```bash
+# Scan current branch
+scancode --license --json-pp current.json .
+
+# Scan main branch
+git checkout main
+scancode --license --json-pp baseline.json .
+git checkout -
+
+# Compute delta (requires deltacode)
+deltacode \
+  --new current.json \
+  --old baseline.json \
+  --json-pp delta.json
+
+# Show only new licenses introduced
+jq '.delta_summary.new_licenses' delta.json
+```
+
+---
+
+## 4. API Integration Example in Python
+
+### 4.1 ScanCode.io REST API Client
+
+#### Complete Python Integration Script
+
+**File:** `ci/scancode_integration.py`
+
+```python
+#!/usr/bin/env python3
+"""
+ScanCode.io CI/CD Integration Script
+Automates project creation, scanning, and result retrieval
+"""
+
+import os
+import sys
+import time
+import requests
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+class ScanCodeIOClient:
+    """Client for ScanCode.io REST API"""
+    
+    def __init__(self, url: str, api_key: str):
+        self.url = url.rstrip('/')
+        self.headers = {
+            'Authorization': f'Token {api_key}',
+            'Content-Type': 'application/json'
+        }
+        self.session = requests.Session()
+        self.session.headers.update(self.headers)
+    
+    def create_project(self, name: str, pipeline: str = 'scan_codebase',
+                      input_urls: Optional[List[str]] = None) -> Dict:
+        """Create a new scan project"""
+        data = {
+            'name': name,
+            'pipeline': pipeline,
+        }
+        if input_urls:
+            data['input_urls'] = input_urls
+        
+        response = self.session.post(
+            f'{self.url}/api/projects/',
+            json=data
+        )
+        response.raise_for_status()
+        return response.json()
+    
+    def upload_file(self, project_uuid: str, file_path: str) -> Dict:
+        """Upload a file to project"""
+        files = {'upload_file': open(file_path, 'rb')}
+        headers = {'Authorization': self.headers['Authorization']}
+        
+        response = requests.post(
+            f'{self.url}/api/projects/{project_uuid}/add_input/',
+            headers=headers,
+            files=files
+        )
+        response.raise_for_status()
+        return response.json()
+    
+    def start_pipeline(self, project_uuid: str) -> Dict:
+        """Start the pipeline execution"""
+        response = self.session.post(
+            f'{self.url}/api/projects/{project_uuid}/execute_pipeline/'
+        )
+        response.raise_for_status()
+        return response.json()
+    
+    def get_project_status(self, project_uuid: str) -> Dict:
+        """Get project status"""
+        response = self.session.get(
+            f'{self.url}/api/projects/{project_uuid}/'
+        )
+        response.raise_for_status()
+        return response.json()
+    
+    def wait_for_completion(self, project_uuid: str, 
+                           timeout: int = 600) -> Dict:
+        """Wait for scan to complete"""
+        start_time = time.time()
+        
+        while True:
+            status = self.get_project_status(project_uuid)
+            
+            if status['status'] == 'success':
+                print(f"✅ Scan completed successfully")
+                return status
+            elif status['status'] == 'failure':
+                print(f"❌ Scan failed: {status.get('message', 'Unknown error')}")
+                sys.exit(1)
+            
+            elapsed = time.time() - start_time
+            if elapsed > timeout:
+                print(f"❌ Timeout after {timeout}s")
+                sys.exit(1)
+            
+            progress = status.get('progress', 0)
+            print(f"⏳ Scanning... {progress}% complete")
+            time.sleep(10)
+    
+    def get_results(self, project_uuid: str, output_format: str = 'json') -> Dict:
+        """Download scan results"""
+        response = self.session.get(
+            f'{self.url}/api/projects/{project_uuid}/results_download/',
+            params={'format': output_format}
+        )
+        response.raise_for_status()
+        return response.json() if output_format == 'json' else response.text
+    
+    def get_packages(self, project_uuid: str) -> List[Dict]:
+        """Get detected packages"""
+        response = self.session.get(
+            f'{self.url}/api/projects/{project_uuid}/packages/'
+        )
+        response.raise_for_status()
+        return response.json()['results']
+    
+    def check_license_policy(self, packages: List[Dict], 
+                            policy: Dict) -> List[Dict]:
+        """Check packages against license policy"""
+        violations = []
+        
+        for pkg in packages:
+            license_expression = pkg.get('declared_license_expression', '')
+            if not license_expression:
+                continue
+            
+            # Check against prohibited licenses
+            for prohibited in policy.get('prohibited', []):
+                if prohibited in license_expression:
+                    violations.append({
+                        'package': pkg['name'],
+                        'version': pkg['version'],
+                        'license': license_expression,
+                        'severity': 'CRITICAL',
+                        'policy': 'prohibited'
+                    })
+        
+        return violations
+    
+    def check_vulnerabilities(self, packages: List[Dict], 
+                             threshold: float = 9.0) -> List[Dict]:
+        """Check for high-severity vulnerabilities"""
+        critical_vulns = []
+        
+        for pkg in packages:
+            vulns = pkg.get('affected_by_vulnerabilities', [])
+            for vuln in vulns:
+                # Parse CVSS score
+                cvss_scores = vuln.get('cvss_scores', [])
+                max_cvss = max([s.get('value', 0) for s in cvss_scores], default=0)
+                
+                if max_cvss >= threshold:
+                    critical_vulns.append({
+                        'package': pkg['name'],
+                        'version': pkg['version'],
+                        'cve': vuln.get('vulnerability_id'),
+                        'cvss': max_cvss,
+                        'summary': vuln.get('summary', '')
+                    })
+        
+        return critical_vulns
+
+
+def scan_repository(repo_path: str, project_name: str) -> int:
+    """
+    Main function to scan a repository
+    Returns: 0 on success, 1 on policy violations
+    """
+    # Configuration from environment
+    scancodeio_url = os.getenv('SCANCODEIO_URL')
+    scancodeio_key = os.getenv('SCANCODEIO_API_KEY')
+    
+    if not scancodeio_url or not scancodeio_key:
+        print("❌ Missing SCANCODEIO_URL or SCANCODEIO_API_KEY")
+        return 1
+    
+    # Load license policy
+    policy_url = os.getenv('LICENSE_POLICY_URL')
+    policy = requests.get(policy_url).json() if policy_url else {}
+    
+    # Initialize client
+    client = ScanCodeIOClient(scancodeio_url, scancodeio_key)
+    
+    # Create archive of repository
+    print(f"📦 Creating archive of {repo_path}")
+    import tarfile
+    archive_path = '/tmp/scan-archive.tar.gz'
+    with tarfile.open(archive_path, 'w:gz') as tar:
+        tar.add(repo_path, arcname='.')
+    
+    # Create project
+    print(f"🚀 Creating ScanCode.io project: {project_name}")
+    project = client.create_project(
+        name=project_name,
+        pipeline='scan_codebase'
+    )
+    project_uuid = project['uuid']
+    print(f"   Project UUID: {project_uuid}")
+    
+    # Upload archive
+    print(f"📤 Uploading codebase")
+    client.upload_file(project_uuid, archive_path)
+    
+    # Start scan
+    print(f"🔍 Starting scan pipeline")
+    client.start_pipeline(project_uuid)
+    
+    # Wait for completion
+    print(f"⏳ Waiting for scan to complete...")
+    client.wait_for_completion(project_uuid, timeout=600)
+    
+    # Get results
+    print(f"📥 Retrieving results")
+    packages = client.get_packages(project_uuid)
+    print(f"   Found {len(packages)} packages")
+    
+    # Check license policy
+    print(f"⚖️  Checking license policy")
+    license_violations = client.check_license_policy(packages, policy)
+    
+    if license_violations:
+        print(f"\n❌ Found {len(license_violations)} license policy violations:")
+        for v in license_violations:
+            print(f"   - {v['package']}@{v['version']}: {v['license']} ({v['policy']})")
+        return 1
+    else:
+        print(f"✅ No license policy violations")
+    
+    # Check vulnerabilities
+    print(f"🛡️  Checking for critical vulnerabilities")
+    critical_vulns = client.check_vulnerabilities(packages, threshold=9.0)
+    
+    if critical_vulns:
+        print(f"\n⚠️  Found {len(critical_vulns)} critical vulnerabilities:")
+        for v in critical_vulns:
+            print(f"   - {v['package']}@{v['version']}: {v['cve']} (CVSS {v['cvss']})")
+        # Don't fail on vulns, just warn (handled separately)
+    
+    # Download full results
+    results = client.get_results(project_uuid, output_format='json')
+    output_file = 'scancode-results.json'
+    with open(output_file, 'w') as f:
+        json.dump(results, f, indent=2)
+    print(f"💾 Results saved to {output_file}")
+    
+    # Generate SBOM
+    print(f"📋 Generating SBOM")
+    sbom_response = client.session.get(
+        f'{scancodeio_url}/api/projects/{project_uuid}/results_download/',
+        params={'format': 'cyclonedx'}
+    )
+    with open('sbom.cdx.json', 'w') as f:
+        f.write(sbom_response.text)
+    print(f"💾 SBOM saved to sbom.cdx.json")
+    
+    return 0
+
+
+if __name__ == '__main__':
+    repo_path = sys.argv[1] if len(sys.argv) > 1 else '.'
+    project_name = os.getenv('CI_PROJECT_NAME', 'ci-scan')
+    
+    exit_code = scan_repository(repo_path, project_name)
+    sys.exit(exit_code)
+```
+
+---
+
+### 4.2 Usage in CI Pipeline
+
+```bash
+# Install dependencies
+pip install requests
+
+# Run scan
+python ci/scancode_integration.py .
+
+# Script exits with:
+# - 0: Success, no violations
+# - 1: Policy violations found, block merge
+```
+
+---
+
+## 5. Sample GitHub Actions Workflow YAML
+
+### 5.1 Pull Request Scan Workflow
+
+**File:** `.github/workflows/scancode-pr.yml`
+
+```yaml
+name: License & Vulnerability Scan (PR)
+
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
+
+env:
+  SCANCODEIO_URL: ${{ secrets.SCANCODEIO_URL }}
+  SCANCODEIO_API_KEY: ${{ secrets.SCANCODEIO_API_KEY }}
+  LICENSE_POLICY_URL: ${{ secrets.LICENSE_POLICY_URL }}
+
+jobs:
+  scan-licenses:
+    name: Scan for License Compliance
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for delta analysis
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      
+      - name: Install dependencies
+        run: |
+          pip install requests python-inspector cyclonedx-bom
+          pip install scancode-toolkit[full]
+      
+      - name: Download license policy
+        run: |
+          curl -sSL -o license-policy.yml "$LICENSE_POLICY_URL"
+      
+      - name: Run ScanCode locally (fast check)
+        id: local-scan
+        run: |
+          # Quick license scan for PR feedback
+          scancode \
+            --license \
+            --license-score 90 \
+            --license-policy license-policy.yml \
+            --json-pp scan-results.json \
+            --processes $(nproc) \
+            .
+          
+          # Check for violations
+          violations=$(jq '[.files[] | select(.license_policy_violations) | 
+                       .license_policy_violations[]] | length' scan-results.json)
+          
+          echo "violations=$violations" >> $GITHUB_OUTPUT
+          
+          if [ "$violations" -gt 0 ]; then
+            echo "::error::Found $violations license policy violations"
+            jq '.files[] | select(.license_policy_violations) | 
+                {path: .path, violations: .license_policy_violations}' \
+                scan-results.json
+            exit 1
+          fi
+      
+      - name: Upload scan results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scancode-results
+          path: scan-results.json
+          retention-days: 30
+      
+      - name: Comment PR with results
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const results = JSON.parse(fs.readFileSync('scan-results.json', 'utf8'));
+            
+            const licenses = new Set();
+            results.files.forEach(file => {
+              if (file.licenses) {
+                file.licenses.forEach(lic => licenses.add(lic.key));
+              }
+            });
+            
+            const violations = ${{ steps.local-scan.outputs.violations }};
+            const status = violations > 0 ? '❌ FAILED' : '✅ PASSED';
+            
+            const body = `## License Scan Results ${status}
+            
+            **Detected Licenses:** ${Array.from(licenses).join(', ') || 'None'}
+            **Policy Violations:** ${violations}
+            **Files Scanned:** ${results.files.length}
+            
+            ${violations > 0 ? '⚠️ **Action Required:** Fix license violations before merging.' : ''}
+            
+            <details>
+            <summary>View detailed results</summary>
+            
+            Download the full scan report from the workflow artifacts.
+            
+            </details>`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+      
+      - name: Set status check
+        if: always()
+        run: |
+          if [ "${{ steps.local-scan.outputs.violations }}" -gt 0 ]; then
+            exit 1
+          fi
+
+  scan-vulnerabilities:
+    name: Scan for Vulnerabilities
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Install ScanCode
+        run: |
+          pip install scancode-toolkit[full]
+      
+      - name: Scan for vulnerabilities
+        id: vuln-scan
+        run: |
+          # Scan packages for vulnerabilities
+          scancode \
+            --package \
+            --json-pp packages.json \
+            .
+          
+          # Extract package list
+          jq -r '.packages[] | "\(.name)@\(.version)"' packages.json > packages.txt
+          
+          echo "Found $(wc -l < packages.txt) packages"
+      
+      - name: Query VulnerableCode
+        env:
+          VULNERABLECODE_URL: ${{ secrets.VULNERABLECODE_URL }}
+        run: |
+          critical_count=0
+          high_count=0
+          
+          while IFS= read -r package; do
+            # Query VulnerableCode API (simplified)
+            # In production, batch these queries
+            echo "Checking: $package"
+          done < packages.txt
+          
+          echo "critical_vulns=$critical_count" >> $GITHUB_OUTPUT
+          echo "high_vulns=$high_count" >> $GITHUB_OUTPUT
+      
+      - name: Notify security team if critical vulnerabilities
+        if: steps.vuln-scan.outputs.critical_vulns > 0
+        uses: slackapi/slack-github-action@v1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_SECURITY }}
+          payload: |
+            {
+              "text": "🚨 Critical Vulnerabilities Detected",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Critical vulnerabilities detected in PR #${{ github.event.pull_request.number }}*\n\nRepository: ${{ github.repository }}\nPR: ${{ github.event.pull_request.html_url }}"
+                  }
+                }
+              ]
+            }
+```
+
+---
+
+### 5.2 Release SBOM Generation Workflow
+
+**File:** `.github/workflows/sbom-release.yml`
+
+```yaml
+name: Generate SBOM on Release
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*'
+
+env:
+  SCANCODEIO_URL: ${{ secrets.SCANCODEIO_URL }}
+  SCANCODEIO_API_KEY: ${{ secrets.SCANCODEIO_API_KEY }}
+
+jobs:
+  generate-sbom:
+    name: Generate and Publish SBOM
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install tools
+        run: |
+          pip install scancode-toolkit[full] cyclonedx-bom spdx-tools
+      
+      - name: Generate SPDX SBOM
+        run: |
+          scancode \
+            --license \
+            --copyright \
+            --package \
+            --info \
+            --spdx-rdf sbom-${{ github.ref_name }}.spdx.json \
+            .
+      
+      - name: Generate CycloneDX SBOM
+        run: |
+          scancode \
+            --license \
+            --copyright \
+            --package \
+            --cyclonedx sbom-${{ github.ref_name }}.cdx.json \
+            .
+      
+      - name: Validate SBOMs
+        run: |
+          # Validate SPDX
+          pyspdxtools -i sbom-${{ github.ref_name }}.spdx.json -v
+          
+          # Validate CycloneDX
+          cyclonedx-py validate --input-file sbom-${{ github.ref_name }}.cdx.json
+      
+      - name: Sign SBOMs with cosign
+        uses: sigstore/cosign-installer@v3
+      
+      - name: Upload SBOMs to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            sbom-${{ github.ref_name }}.spdx.json
+            sbom-${{ github.ref_name }}.cdx.json
+          fail_on_unmatched_files: true
+      
+      - name: Upload to artifact registry
+        run: |
+          # Upload to company artifact registry
+          # curl -X POST $ARTIFACT_REGISTRY_URL ...
+          echo "SBOM uploaded to artifact registry"
+```
+
+---
+
+### 5.3 Scheduled Full Audit Workflow
+
+**File:** `.github/workflows/security-audit.yml`
+
+```yaml
+name: Weekly Security Audit
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'  # Every Monday at 2 AM UTC
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  full-audit:
+    name: Comprehensive Security Audit
+    runs-on: ubuntu-latest-8-cores  # Use larger runner
+    timeout-minutes: 120
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Run comprehensive scan
+        run: |
+          python ci/scancode_integration.py .
+      
+      - name: Generate audit report
+        run: |
+          python ci/generate_audit_report.py \
+            --input scancode-results.json \
+            --output audit-report.html \
+            --format html
+      
+      - name: Upload to secure storage
+        run: |
+          # Upload to S3, GCS, or internal storage
+          # aws s3 cp audit-report.html s3://security-audits/$(date +%Y-%m-%d)/
+          echo "Report uploaded"
+      
+      - name: Notify compliance team
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.company.com
+          server_port: 587
+          username: ${{ secrets.SMTP_USERNAME }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          subject: Weekly Security Audit - ${{ github.repository }}
+          to: compliance@company.com,security@company.com
+          from: DevOps <devops@company.com>
+          body: |
+            Weekly security audit completed for ${{ github.repository }}.
+            
+            View the detailed report in the attached artifacts.
+          attachments: audit-report.html
+```
+
+---
+
+## 6. Interpreting Scan Output
+
+### 6.1 JSON Output Structure
+
+#### ScanCode Toolkit Output Schema
+
+```json
+{
+  "headers": [
+    {
+      "tool_name": "scancode-toolkit",
+      "tool_version": "32.0.0",
+      "options": {
+        "license": true,
+        "copyright": true,
+        "package": true
+      },
+      "duration": 234.56,
+      "message": null,
+      "errors": [],
+      "warnings": []
+    }
+  ],
+  "files": [
+    {
+      "path": "src/main.py",
+      "type": "file",
+      "name": "main.py",
+      "size": 1234,
+      "sha1": "abc123...",
+      "licenses": [
+        {
+          "key": "mit",
+          "score": 100.0,
+          "name": "MIT License",
+          "category": "Permissive",
+          "start_line": 1,
+          "end_line": 20,
+          "matched_text": "Permission is hereby granted..."
+        }
+      ],
+      "license_expressions": ["mit"],
+      "copyrights": [
+        {
+          "copyright": "Copyright 2024 Company Inc.",
+          "start_line": 3,
+          "end_line": 3
+        }
+      ],
+      "license_policy_violations": []  // Empty = compliant
+    }
+  ],
+  "packages": [
+    {
+      "type": "pypi",
+      "namespace": null,
+      "name": "requests",
+      "version": "2.31.0",
+      "purl": "pkg:pypi/requests@2.31.0",
+      "declared_license_expression": "Apache-2.0",
+      "license_detections": [...],
+      "affected_by_vulnerabilities": [
+        {
+          "vulnerability_id": "CVE-2023-32681",
+          "summary": "Unintended leak of Proxy-Authorization header",
+          "cvss_scores": [
+            {
+              "value": 6.1,
+              "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:N/A:N"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### 6.2 Key Metrics to Extract
+
+#### License Analysis
+
+```python
+# Parse license distribution
+import json
+from collections import Counter
+
+with open('scan-results.json') as f:
+    data = json.load(f)
+
+# Count license occurrences
+license_counter = Counter()
+for file_data in data['files']:
+    for license in file_data.get('license_expressions', []):
+        license_counter[license] += 1
+
+print("License Distribution:")
+for license, count in license_counter.most_common():
+    print(f"  {license}: {count} files")
+
+# Identify policy violations
+violations = []
+for file_data in data['files']:
+    if file_data.get('license_policy_violations'):
+        violations.append({
+            'path': file_data['path'],
+            'violations': file_data['license_policy_violations']
+        })
+
+if violations:
+    print(f"\n❌ {len(violations)} files with policy violations")
+else:
+    print("\n✅ No policy violations")
+```
+
+---
+
+#### Vulnerability Analysis
+
+```python
+# Extract high-severity vulnerabilities
+import json
+
+with open('scan-results.json') as f:
+    data = json.load(f)
+
+critical_vulns = []
+high_vulns = []
+
+for pkg in data.get('packages', []):
+    package_name = f"{pkg['name']}@{pkg['version']}"
+    
+    for vuln in pkg.get('affected_by_vulnerabilities', []):
+        cvss_scores = vuln.get('cvss_scores', [])
+        max_cvss = max([s.get('value', 0) for s in cvss_scores], default=0)
+        
+        vuln_data = {
+            'package': package_name,
+            'cve': vuln['vulnerability_id'],
+            'cvss': max_cvss,
+            'summary': vuln.get('summary', '')
+        }
+        
+        if max_cvss >= 9.0:
+            critical_vulns.append(vuln_data)
+        elif max_cvss >= 7.0:
+            high_vulns.append(vuln_data)
+
+print(f"Critical vulnerabilities (CVSS 9.0+): {len(critical_vulns)}")
+print(f"High vulnerabilities (CVSS 7.0-8.9): {len(high_vulns)}")
+
+# Output for downstream processing
+summary = {
+    'critical_count': len(critical_vulns),
+    'high_count': len(high_vulns),
+    'critical_vulns': critical_vulns,
+    'high_vulns': high_vulns
+}
+
+with open('vuln-summary.json', 'w') as f:
+    json.dump(summary, f, indent=2)
+```
+
+---
+
+### 6.3 Dashboard Integration
+
+#### Export to Prometheus/Grafana
+
+```python
+# Export metrics for monitoring
+from prometheus_client import CollectorRegistry, Gauge, write_to_textfile
+
+registry = CollectorRegistry()
+
+# Define metrics
+license_violations = Gauge(
+    'scancode_license_violations_total',
+    'Total license policy violations',
+    ['repository', 'branch'],
+    registry=registry
+)
+
+critical_vulns_metric = Gauge(
+    'scancode_critical_vulnerabilities_total',
+    'Total critical vulnerabilities',
+    ['repository', 'branch'],
+    registry=registry
+)
+
+# Set values from scan results
+license_violations.labels(
+    repository='myapp',
+    branch='main'
+).set(len(violations))
+
+critical_vulns_metric.labels(
+    repository='myapp',
+    branch='main'
+).set(len(critical_vulns))
+
+# Write to file for node_exporter
+write_to_textfile('/var/lib/node_exporter/scancode.prom', registry)
+```
+
+---
+
+## 7. Escalation Path for Flagged Vulnerabilities
+
+### 7.1 Severity-Based Escalation Matrix
+
+| CVSS Score | Severity | SLA | Notification | Action |
+|------------|----------|-----|--------------|---------|
+| 9.0-10.0 | Critical | 24 hours | Security team + CISO | Block production deployment |
+| 7.0-8.9 | High | 7 days | Security team | Require remediation plan |
+| 4.0-6.9 | Medium | 30 days | Dev team lead | Track in backlog |
+| 0.1-3.9 | Low | 90 days | No alert | Document only |
+
+---
+
+### 7.2 Automated Escalation Workflow
+
+#### Vulnerability Triage Script
+
+**File:** `ci/triage_vulnerabilities.py`
+
+```python
+#!/usr/bin/env python3
+"""
+Automated vulnerability triage and escalation
+"""
+
+import json
+import os
+import sys
+from datetime import datetime
+import requests
+
+def send_slack_alert(webhook_url: str, vulnerability: dict):
+    """Send Slack notification for critical vulnerabilities"""
+    message = {
+        "text": f"🚨 Critical Vulnerability Detected: {vulnerability['cve']}",
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": f"Critical Vulnerability: {vulnerability['cve']}"
+                }
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"*Package:*\n{vulnerability['package']}"},
+                    {"type": "mrkdwn", "text": f"*CVSS Score:*\n{vulnerability['cvss']}"},
+                    {"type": "mrkdwn", "text": f"*Repository:*\n{os.getenv('GITHUB_REPOSITORY')}"},
+                    {"type": "mrkdwn", "text": f"*Branch:*\n{os.getenv('GITHUB_REF_NAME')}"}
+                ]
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Summary:*\n{vulnerability['summary'][:500]}"
+                }
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "View in GitHub"},
+                        "url": os.getenv('GITHUB_SERVER_URL') + '/' + 
+                               os.getenv('GITHUB_REPOSITORY') + 
+                               '/actions/runs/' + os.getenv('GITHUB_RUN_ID')
+                    }
+                ]
+            }
+        ]
+    }
+    
+    requests.post(webhook_url, json=message)
+
+def create_jira_ticket(vulnerability: dict):
+    """Create Jira ticket for vulnerability tracking"""
+    jira_url = os.getenv('JIRA_URL')
+    jira_token = os.getenv('JIRA_API_TOKEN')
+    
+    ticket = {
+        "fields": {
+            "project": {"key": "SEC"},
+            "summary": f"[CRITICAL] {vulnerability['cve']} in {vulnerability['package']}",
+            "description": f"""
+Critical vulnerability detected in automated scan.
+
+*Package:* {vulnerability['package']}
+*CVE:* {vulnerability['cve']}
+*CVSS Score:* {vulnerability['cvss']}
+*Repository:* {os.getenv('GITHUB_REPOSITORY')}
+
+*Summary:*
+{vulnerability['summary']}
+
+*Action Required:*
+- Assess impact on production systems
+- Identify affected services
+- Develop remediation plan within 24 hours
+- Update to patched version or implement workaround
+
+*Automated Detection:*
+This ticket was created automatically by the CI/CD security scanner.
+            """,
+            "issuetype": {"name": "Security Incident"},
+            "priority": {"name": "Critical"},
+            "labels": ["security", "automated", "vulnerability", vulnerability['cve']]
+        }
+    }
+    
+    headers = {
+        "Authorization": f"Bearer {jira_token}",
+        "Content-Type": "application/json"
+    }
+    
+    response = requests.post(
+        f"{jira_url}/rest/api/3/issue",
+        json=ticket,
+        headers=headers
+    )
+    
+    return response.json()
+
+def triage_scan_results(results_file: str):
+    """Main triage function"""
+    with open(results_file) as f:
+        data = json.load(f)
+    
+    critical_vulns = []
+    high_vulns = []
+    
+    # Extract vulnerabilities
+    for pkg in data.get('packages', []):
+        package_name = f"{pkg['name']}@{pkg['version']}"
+        
+        for vuln in pkg.get('affected_by_vulnerabilities', []):
+            cvss_scores = vuln.get('cvss_scores', [])
+            max_cvss = max([s.get('value', 0) for s in cvss_scores], default=0)
+            
+            vuln_data = {
+                'package': package_name,
+                'purl': pkg.get('purl'),
+                'cve': vuln['vulnerability_id'],
+                'cvss': max_cvss,
+                'summary': vuln.get('summary', ''),
+                'references': vuln.get('references', [])
+            }
+            
+            if max_cvss >= 9.0:
+                critical_vulns.append(vuln_data)
+            elif max_cvss >= 7.0:
+                high_vulns.append(vuln_data)
+    
+    # Escalate critical vulnerabilities
+    if critical_vulns:
+        print(f"🚨 CRITICAL: {len(critical_vulns)} critical vulnerabilities found")
+        
+        # Send Slack alerts
+        slack_webhook = os.getenv('SLACK_WEBHOOK_SECURITY')
+        if slack_webhook:
+            for vuln in critical_vulns:
+                send_slack_alert(slack_webhook, vuln)
+        
+        # Create Jira tickets
+        if os.getenv('JIRA_URL'):
+            for vuln in critical_vulns:
+                ticket = create_jira_ticket(vuln)
+                print(f"   Created Jira ticket: {ticket.get('key')}")
+        
+        # Block deployment
+        print("❌ BLOCKING: Critical vulnerabilities must be resolved")
+        return 1
+    
+    # Report high vulnerabilities
+    if high_vulns:
+        print(f"⚠️  WARNING: {len(high_vulns)} high-severity vulnerabilities found")
+        print("   Remediation required within 7 days")
+        # Don't block, but create tickets
+    
+    return 0
+
+if __name__ == '__main__':
+    results_file = sys.argv[1] if len(sys.argv) > 1 else 'vuln-summary.json'
+    exit_code = triage_scan_results(results_file)
+    sys.exit(exit_code)
+```
+
+---
+
+### 7.3 Integration with Incident Response
+
+#### PagerDuty Integration for Critical CVEs
+
+```python
+import requests
+
+def trigger_pagerduty_incident(vulnerability: dict):
+    """Trigger PagerDuty incident for critical vulnerability"""
+    
+    pagerduty_key = os.getenv('PAGERDUTY_INTEGRATION_KEY')
+    
+    event = {
+        "routing_key": pagerduty_key,
+        "event_action": "trigger",
+        "payload": {
+            "summary": f"Critical vulnerability {vulnerability['cve']} in production",
+            "severity": "critical",
+            "source": "AboutCode Security Scanner",
+            "custom_details": {
+                "package": vulnerability['package'],
+                "cve": vulnerability['cve'],
+                "cvss_score": vulnerability['cvss'],
+                "repository": os.getenv('GITHUB_REPOSITORY'),
+                "affected_systems": "Production microservices"
+            }
+        }
+    }
+    
+    response = requests.post(
+        "https://events.pagerduty.com/v2/enqueue",
+        json=event
+    )
+    
+    return response.json()
+```
+
+---
+
+### 7.4 Remediation Tracking
+
+#### Generate Remediation Report
+
+```bash
+# Track vulnerability remediation progress
+cat > remediation-report.sh << 'EOF'
+#!/bin/bash
+
+# Generate CSV report for tracking
+echo "CVE,Package,CVSS,Status,Assignee,Due Date,Notes" > vulns.csv
+
+jq -r '.packages[] | 
+  select(.affected_by_vulnerabilities) | 
+  .affected_by_vulnerabilities[] as $vuln |
+  [
+    $vuln.vulnerability_id,
+    .name + "@" + .version,
+    ($vuln.cvss_scores[0].value // 0),
+    "Open",
+    "TBD",
+    (now + 604800 | strftime("%Y-%m-%d")),
+    ""
+  ] | @csv' scancode-results.json >> vulns.csv
+
+echo "Remediation tracking report generated: vulns.csv"
+EOF
+
+chmod +x remediation-report.sh
+./remediation-report.sh
+```
+
+---
+
+## Success Metrics & Monitoring
+
+### Key Performance Indicators
+
+```python
+# Track CI/CD integration metrics
+metrics = {
+    "scan_coverage": "100%",  # All PRs scanned
+    "avg_scan_time": "3.2 minutes",
+    "blocked_merges_30d": 5,  # PRs blocked due to violations
+    "false_positive_rate": "0.8%",
+    "sbom_generation_success_rate": "99.7%",
+    "critical_vuln_mttr": "14 hours",  # Mean time to resolution
+    "license_violations_prevented": 7
+}
+```
+
+### Dashboard Queries (Grafana)
+
+```promql
+# License violation rate
+rate(scancode_license_violations_total[7d])
+
+# Critical vulnerability detection
+sum(scancode_critical_vulnerabilities_total) by (repository)
+
+# Scan success rate
+rate(scancode_scan_success_total[1h]) / 
+rate(scancode_scan_total[1h])
+```
+
+---
+
+## Conclusion
+
+This integration provides:
+
+✅ **Automated license compliance enforcement** preventing policy violations from reaching production  
+✅ **Real-time vulnerability detection** with severity-based escalation  
+✅ **Continuous SBOM generation** for every release  
+✅ **Multi-channel alerting** (Slack, email, PagerDuty, Jira)  
+✅ **Audit trail** with full scan history and remediation tracking  
+✅ **Developer-friendly** integration in existing GitHub Actions workflows
+
+**Next Steps:**
+1. Deploy ScanCode.io and VulnerableCode instances
+2. Configure license policy and escalation webhooks
+3. Roll out to pilot repositories
+4. Monitor metrics and tune thresholds
+5. Expand to all production repositories
+6. Integrate with security dashboard (Grafana/Datadog)
+
+---
+
+**Documentation References:**
+- `developer/getting-started.html` - Developer onboarding
+- `developer/guides/ci-cd-integration-patterns.html` - CI/CD patterns
+- `developer/reference/cli-options-complete.html` - ScanCode CLI reference
+- `developer/reference/rest-api-complete.html` - API documentation
+- `security/guides/triage-vulnerabilities.html` - Vulnerability handling
+- `aboutcode-projects/scancodeio-project.html` - ScanCode.io overview
+
+**Support:**
+- GitHub Issues: https://github.com/aboutcode-org/scancode.io/issues
+- Community Chat: https://gitter.im/aboutcode-org/discuss
+- API Documentation: https://scancodeio.readthedocs.io/
+
+---
+
+*Last Updated: February 2026 | Alex Rivera, Platform Engineering Team*

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ docs =
     Sphinx
     sphinx-rtd-theme
     sphinx-reredirects
+    sphinx-design
     doc8
     sphinx-autobuild
     sphinx-rtd-dark-mode


### PR DESCRIPTION
The existing AboutCode documentation was structured around tool functionality with no consideration for the different types of users accessing it. Research in #249 identified three distinct personas — Legal/Compliance Officers, Security Researchers, and Dev/Integrators — each with different needs and entry points. The docs had no persona-aware structure, causing non-technical users to hit jargon walls and developers to wade through irrelevant content.
What I Did

Audited all existing .rst/.md files and tagged each by target persona
Produced a gap analysis identifying which roles were underserved
Proposed a new Sphinx site map with a "Choose Your Own Adventure" landing page routing users by role
Drafted User Journey docs for two primary personas: first-time Compliance Officer and Senior DevOps Engineer
Added a glossary of technical terms written for non-technical readers
Added a Python script to auto-tag doc files by persona using keyword matching.
Signed-off-by: Zeba Fatma Khan<khanz@rknec.edu>

