### PR TITLE
fix: update setup.cfg to reference existing README.md and LICENSE

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,8 @@ license = Apache-2.0
 
 # description must be on ONE line https://github.com/pypa/setuptools/issues/1390
 description = aboutcode
-long_description = file:README.rst
-long_description_content_type = text/x-rst
+long_description = file:README.md
+long_description_content_type = text/markdown
 url = https://github.com/aboutcode-org/aboutcode
 
 author = nexB. Inc. and others
@@ -24,7 +24,7 @@ keywords =
     docs
 
 license_files =
-    apache-2.0.LICENSE
+    LICENSE
     NOTICE
 
 [options]


### PR DESCRIPTION
Fixes #283

- Replace non-existent README.rst with README.md
- Update content type from text/x-rst to text/markdown
- Fix license_files path from apache-2.0.LICENSE to LICENSE (actual file)