### PR TITLE
fix: add actual link check step to sphinx_build_link_check.sh

### DIFF
--- a/docs/scripts/sphinx_build_link_check.sh
+++ b/docs/scripts/sphinx_build_link_check.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # halt script on error
 set -e
-# Build locally, and then check links
+# Build the HTML docs
 sphinx-build -E -W source build
+# Check links in the docs
+sphinx-build -b linkcheck source build/linkcheck


### PR DESCRIPTION
Fixes #284

The script was named sphinx_build_link_check and commented as "Build locally, and then check links" but only ran the HTML build step. Adds the missing sphinx-build -b linkcheck command.